### PR TITLE
fix: release gate ต้องคุม v2 ด้วย ไม่ใช่แค่ main

### DIFF
--- a/platform-contract.yaml
+++ b/platform-contract.yaml
@@ -88,17 +88,26 @@ conformance:
   status: passing
   last_verified: "2026-08-23"
 
-  # ขอบเขตของ gate — เขียนไว้ให้ตรงตามจริง
-  #   บังคับที่ `main` (สายที่ปล่อยของจริง) · `v2` เป็นสายพัฒนา ยังไม่ใส่ required check
-  #   โดยตั้งใจ เพราะจะทำให้ push ตรงไม่ได้ทั้งที่ยังเป็น repo คนเดียว
-  #   จะใส่ตอน v2 เริ่มมีผู้ร่วมพัฒนา
+  # ขอบเขตของ gate — คุมทั้งสอง branch
+  #
+  #   main  สายที่ freeze ไว้ที่ tag v1-final — bot 14 ตัวที่ deploy อยู่ยึด commit นั้น
+  #   v2    สายที่ขยับจริง manifest และ conformance อยู่ที่นี่
+  #
+  #   ⚠️ เดิมคุมแค่ main ซึ่งผิด — ADR-0006 ข้อ 3 บังคับ release gate ไม่ใช่แค่ "CI ที่รัน"
+  #      gate ที่คุม branch ที่ freeze ไว้ ไม่ได้กันอะไรเลยบน branch ที่งานเดินอยู่
+  #      แก้ตามที่ agent-platform#43 ทักมา
   release_gate:
-    ruleset: "V1 freeze — main"
-    branch: main
     bypass_actors: 0
     required_checks:
       - "packages — test + typecheck"
       - "conformance — ADR-0006"
+    rulesets:
+      - name: "V1 freeze — main"
+        branch: main
+        rules: [deletion, non_fast_forward, pull_request, required_status_checks]
+      - name: "V2 release gate — v2"
+        branch: v2
+        rules: [non_fast_forward, pull_request, required_status_checks]
 
   checks:
     - name: drift_check


### PR DESCRIPTION
ปิดจุดที่ [agent-platform#43](https://github.com/monthop-gmail/agent-platform/issues/43) ทักมา

## ที่ผิด

ruleset เดิม `V1 freeze — main` คุม `refs/heads/main` อย่างเดียว ซึ่งเป็น branch ที่ **freeze ไว้แล้ว**
ส่วน `v2` ที่งานเดินอยู่จริง — `platform-contract.yaml` · `conformance/` · `packages/` — ไม่มีอะไรคุมเลย

```text
check รันจริงบน v2 และเขียว           ✅
แต่ถ้ามันแดง merge เข้า v2 ได้อยู่ดี    ❌
```

ADR-0006 ข้อ 3 บังคับ **release gate** ไม่ใช่แค่ *"CI ที่รัน"*

## ที่แก้

เพิ่ม ruleset `V2 release gate — v2`

```
target        refs/heads/v2
enforcement   active
bypass_actors 0
rules         non_fast_forward · pull_request (approve 0) · required_status_checks
required      packages — test + typecheck / conformance — ADR-0006
```

`approve 0` เพราะ GitHub ไม่ให้ approve PR ของตัวเอง — repo คนเดียวถ้าตั้ง 1 จะ merge ไม่ได้เลย
แต่ยังบังคับให้ผ่าน PR + CI เขียว ซึ่งเป็นสาระของ gate

manifest บันทึก ruleset ทั้งสองไว้ที่ `conformance.release_gate` ให้ตรวจได้จากไฟล์ ไม่ต้องเชื่อคำอธิบาย

## หลักฐานว่า gate กัดจริง

PR นี้เกิดขึ้นเพราะ push ตรงถูกปฏิเสธ:

```
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
 ! [remote rejected] v2 -> v2 (push declined due to repository rule violations)
```

ผลข้างเคียงที่ตั้งใจ: ตั้งแต่นี้ทุกอย่างที่เข้า `v2` ต้องผ่าน PR
