### PR TITLE
feat(adapter-codex): RuntimePort บน codex app-server — stdio transport

### DIFF
--- a/docs/architecture/runtime-matrix.md
+++ b/docs/architecture/runtime-matrix.md
@@ -1,0 +1,82 @@
+# Runtime Matrix
+
+**2026-08-23** · ตอบคำถามว่า engine ไหนมี **server mode** ให้ใช้ และตัวไหนยังต้อง spawn ต่อ request
+
+เอกสารนี้เป็นหนึ่งใน deliverable ของ Phase 0 ที่ค้างอยู่ ([`ref/botforge-v2-architecture-direction.md`](../../ref/botforge-v2-architecture-direction.md) §16)
+
+---
+
+## 1. โหมดของแต่ละ engine ที่ `v1-final`
+
+| engine | โหมดจริง | process อยู่ยาว? | หลักฐาน |
+| --- | --- | :-: | --- |
+| `opencode` | OpenCode serve — HTTP แยก container | ✅ | `docker-compose.yml` service `opencode` |
+| `claude-code` | Agent SDK **ใน process** ของ Hono | ✅ | `@anthropic-ai/claude-agent-sdk` · ไม่มี `spawn` |
+| `copilot-cli` | Copilot SDK **ใน process** | ✅ | `@github/copilot-sdk` · ไม่มี `spawn` |
+| `gocode` | server ที่เราเขียนเอง (Go + chi) | ✅ | `server/main.go` |
+| `adkcode` | server ที่เราเขียนเอง (FastAPI + ADK) | ✅ | `server/api.py` |
+| `codex-appserver` | `codex app-server --listen ws://…` | ✅ | `server/entrypoint.sh` |
+| **`codex`** | **`spawn("codex", …)` ต่อ request** | ❌ | `server/src/codex.ts:53` |
+| **`gemini-cli`** | **`spawn()` ต่อ request** | ❌ | `server/src/gemini.ts` |
+| **`qwen-code`** | **`spawn()` ต่อ request** | ❌ | `server/src/qwen.ts` |
+
+**3 ตัวที่ยัง spawn ต่อ request** — `codex` · `gemini-cli` · `qwen-code`
+
+---
+
+## 2. upstream มี server mode ให้ไหม
+
+| CLI | server mode | สถานะ | ใช้ได้เลยไหม |
+| --- | --- | --- | :-: |
+| **Codex** | `codex app-server` | JSON-RPC 2.0 · harness เดียวกับที่ขับ Codex ทุก surface (web · CLI · IDE · macOS) | ✅ |
+| **Qwen Code** | `qwen serve` | HTTP + SSE · ship ตั้งแต่ v0.16-alpha · Stage 1 merged พ.ค. 2026 · **experimental** | ⚠️ |
+| **Gemini CLI** | daemon mode | [PR #20700](https://github.com/google-gemini/gemini-cli/pull/20700) **ยังไม่ merge** (เปิดค้างตั้งแต่ มิ.ย. 2026 · unix socket) | ❌ |
+
+> ⚠️ ผลค้นหาเว็บสรุปว่า Gemini CLI *"has introduced daemon mode"* — **ไม่จริง** ต้องเปิด PR ดูเองถึงเห็นว่ายังไม่ merge ติด security review + CI แดง
+
+---
+
+## 3. transport ของ Codex app-server — จุดที่ v1 เลือกผิด
+
+app-server มีสอง transport และคุณภาพต่างกันชัด:
+
+| transport | สถานะจาก upstream |
+| --- | --- |
+| **stdio** (spawn child ครั้งเดียว · newline-delimited JSON บน stdin/stdout) | ✅ **stable · production-ready** — ทางที่ VS Code extension และ Python SDK ใช้ |
+| `--listen ws://…` | ⚠️ **"Experimental, unsupported"** — ไม่รับประกันความเข้ากันได้ระหว่าง version |
+
+`bot-service-codex-appserver/server/entrypoint.sh` ใช้:
+
+```bash
+codex app-server --listen "ws://0.0.0.0:$PORT" &
+```
+
+คือตัวที่ upstream เขียนเองว่าไม่ซัพพอร์ต · template นี้มี **0 project ใช้จริง** จาก 14
+
+**V2 ใช้ stdio** — ดู [`packages/adapter-codex`](../../packages/adapter-codex/)
+
+---
+
+## 4. แผน
+
+| engine | ทำอะไร | สถานะ |
+| --- | --- | :-: |
+| `opencode` | adapter บน OpenCode serve | ✅ [`adapter-opencode`](../../packages/adapter-opencode/) |
+| `codex` + `codex-appserver` | **ยุบเป็นตัวเดียว** บน app-server/stdio | ✅ [`adapter-codex`](../../packages/adapter-codex/) |
+| `claude-code` · `copilot-cli` | SDK อยู่ใน process แล้ว — ห่อเป็น adapter | ⬜ |
+| `gocode` · `adkcode` | server ของเราเอง — ห่อเป็น adapter | ⬜ |
+| `qwen-code` | รอ `qwen serve` ออกจาก experimental (Stage 2 ทำ WebSocket/OpenAPI) | ⬜ |
+| `gemini-cli` | ยังไม่มีทางเลือก — spawn ต่อไปจนกว่า PR merge | ⬜ |
+
+การยุบ `codex` + `codex-appserver` ตรงกับ Q3 ที่ตัดสินไว้ว่ายุบได้ และตรงกับที่ [`current-state.md`](current-state.md) §2.1 วัดได้ว่าฝั่ง bot ของสองตัวนี้ **เหมือนกันทุก byte**
+
+`RuntimePort` รองรับทั้งสองแบบอยู่แล้ว — adapter ที่ spawn ต่อ request ก็ implement `sendPrompt()` ได้เหมือนกัน ต่างแค่ประสิทธิภาพ
+
+---
+
+## 5. ที่มา
+
+- [OpenAI — Unlocking the Codex harness](https://openai.com/index/unlocking-the-codex-harness/)
+- [codex app-server developer guide](https://gist.github.com/oneryalcin/ee2c27e2d8aa040da8fbe7eebcc2ecea) — ที่มาของเรื่อง transport
+- [gemini-cli PR #20700](https://github.com/google-gemini/gemini-cli/pull/20700)
+- [Qwen Code — daemon mode (`qwen serve`)](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve/)

--- a/packages/adapter-codex/README.md
+++ b/packages/adapter-codex/README.md
@@ -1,0 +1,97 @@
+# @botforge/adapter-codex
+
+`RuntimePort` บน [`codex app-server`](https://openai.com/index/unlocking-the-codex-harness/) — **stdio JSON-RPC 2.0**
+
+## ทำไมต้อง app-server ไม่ใช่ `spawn("codex")`
+
+v1 มี codex สองแบบ และทั้งคู่มีปัญหาคนละอย่าง:
+
+| template | โหมด | ปัญหา |
+| --- | --- | --- |
+| `bot-service-codex` | `spawn("codex", …)` **ทุก request** | ไม่มี process อยู่ยาว · จ่ายค่า startup ทุกข้อความ · state อยู่ที่ไหนไม่ชัด |
+| `bot-service-codex-appserver` | `codex app-server --listen ws://…` | ใช้ transport ที่ **upstream ระบุเองว่า "Experimental, unsupported"** |
+
+adapter นี้เอาข้อดีของแบบหลัง (process อยู่ยาว ถือ thread) มาวางบน transport ที่ upstream รับประกัน
+
+```
+stdio                ✅ stable · production-ready · ทางที่ VS Code extension และ Python SDK ใช้
+--listen ws://…      ⚠️ experimental · ไม่รับประกันความเข้ากันได้ระหว่าง version
+```
+
+app-server เป็น harness เดียวกับที่ขับ Codex ทุก surface — web, CLI, IDE extension, macOS app
+
+## ลองเลย
+
+```bash
+# ต้องมี codex CLI และล็อกอินแล้ว
+node --experimental-strip-types scripts/smoke-codex.ts "ช่วยอธิบาย docker compose สั้น ๆ"
+
+# ไม่มี codex ก็ลองได้ — ใช้ app-server ปลอมใน fixtures
+BOTFORGE_CODEX_FAKE=1 node --experimental-strip-types scripts/smoke-codex.ts "ทดสอบ"
+```
+
+## โครง
+
+| ไฟล์ | หน้าที่ |
+| --- | --- |
+| `jsonrpc.ts` | JSON-RPC 2.0 client แบบ line-delimited — ไม่ผูก transport |
+| `stdio.ts` | spawn `codex app-server` ครั้งเดียว คุยผ่าน stdin/stdout |
+| `appserver.ts` | handshake `initialize` → `initialized` |
+| `prompt.ts` | ประกอบ prefix แบบ codex |
+| `adapter.ts` | thread ต่อ `sessionKey` · turn · auto-approve · interrupt |
+
+## protocol ที่ใช้
+
+```
+initialize / initialized                    handshake ครั้งเดียวต่อ connection
+thread/start   {model, cwd, approvalPolicy, sandboxPolicy} → {thread:{id}}
+turn/start     {threadId, input:[{type:"text",text}], …}
+  ← turn/started                {turn:{id}}
+  ← item/agentMessage/delta     {text}          สตรีมทีละก้อน
+  ← turn/completed              {turn:{status, items, codexErrorInfo}}
+  ← item/*/requestApproval      → ตอบด้วย item/*/respondApproval
+turn/interrupt {threadId, turnId}            หยุด turn โดยไม่ทำลาย thread
+```
+
+`turn/interrupt` = `cancellation: graceful` ตาม `provider/v1/agent-provider` — ต่างจาก `gocode` ที่ `/abort` ไปลบ session ทิ้ง (`kill_only`)
+
+## ⚠️ ค่าเริ่มต้นเปิดกว้างมาก — ยกมาจาก v1 ตามจริง
+
+```ts
+approvalPolicy: "never"
+sandboxPolicy:  { type: "dangerFullAccess" }
+autoApprove:    true      // ตอบรับทุกคำขอ command/file
+```
+
+นี่คือสิ่งที่ `bot-service-codex-appserver` ทำอยู่ **ยกมาเหมือนเดิมเพื่อไม่เปลี่ยนพฤติกรรมเงียบ ๆ**
+
+แต่ในบริบทของ LINE bot แปลว่า **ใครก็ตามที่พิมพ์ในกลุ่มสั่งให้ agent อ่าน/เขียนไฟล์อะไรก็ได้ใน workspace**
+ควรบีบให้แคบลงก่อนใช้กับ bot ที่คนนอกเข้าถึงได้:
+
+```ts
+new CodexAdapter({
+  sandboxPolicy: { type: "workspaceWrite" },   // ตามที่ app-server รองรับ
+  autoApprove: false,                          // แต่ต้องมีคนตอบ ไม่งั้น turn ค้าง
+})
+```
+
+ปิด `autoApprove` แล้ว**ไม่มีใครตอบ** turn จะค้างจนหมดเวลา — มี test ล็อกพฤติกรรมนี้ไว้
+
+## test
+
+```bash
+npm test --prefix packages/adapter-codex
+```
+
+25 test · **ทุกตัวคุยกับ child process จริง** ผ่าน stdio ไม่ใช่ mock ของ `spawn`
+
+`fixtures/fake-app-server.mjs` พูด JSON-RPC เหมือนของจริง และ **จงใจเขียน stdout เป็นก้อนละ 7 ตัวอักษร**
+เพื่อพิสูจน์ว่า framing ต่อเศษบรรทัดถูก — ของจริงก็ไม่รับประกันว่า chunk จะตรงขอบ message
+กับ **เขียน log ที่ไม่ใช่ JSON ปนมาทาง stdout** เพราะ app-server จริงก็ทำ
+
+## ยังไม่ได้ทำ
+
+- ยังไม่ได้ยิง `codex app-server` ตัวจริง — เครื่องที่พัฒนาไม่มี codex CLI
+  โครง protocol ถอดมาจาก `bot-service-codex-appserver` ที่ v1 เขียนไว้และพูดกับของจริงได้
+- `cost_usd` — v1 ก็คืน 0 ตลอด · app-server มี usage ใน turn แต่ยังไม่ได้ map
+- resume thread ข้าม restart — `thread/resume` มีใน protocol แต่ adapter ยังไม่เก็บ threadId ลง storage

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@botforge/adapter-codex",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "description": "RuntimePort adapter สำหรับ codex app-server — stdio JSON-RPC transport ที่ upstream รับประกัน",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": { "@botforge/core": "^0.0.1" },
+  "devDependencies": { "@types/node": "^22", "typescript": "^5.7.0" }
+}

--- a/packages/adapter-codex/src/adapter.test.ts
+++ b/packages/adapter-codex/src/adapter.test.ts
@@ -1,0 +1,161 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { fileURLToPath } from "node:url"
+import { CodexAdapter } from "./adapter.ts"
+import { buildPrefix, GROUP_CHAT_INSTRUCTION } from "./prompt.ts"
+
+/**
+ * ทุก test ในไฟล์นี้คุยกับ **child process จริง** ผ่าน stdio
+ * `fixtures/fake-app-server.mjs` พูด JSON-RPC เหมือนของจริง และจงใจเขียน stdout
+ * เป็นก้อนละ 7 ตัวอักษร เพื่อพิสูจน์ว่า framing ต่อเศษบรรทัดถูก
+ */
+const FAKE = fileURLToPath(new URL("./fixtures/fake-app-server.mjs", import.meta.url))
+
+function make(over: Record<string, unknown> = {}) {
+  return new CodexAdapter({
+    command: process.execPath,
+    args: [FAKE],
+    workspaceDir: "/workspace",
+    promptTimeoutMs: 3000,
+    ...over,
+  })
+}
+
+const prompt = (over: Record<string, unknown> = {}) => ({
+  sessionKey: "line-c1", userId: "U1", text: "สวัสดี", isGroup: false, ...over,
+}) as any
+
+test("คุยกับ app-server จริงผ่าน stdio ได้ — delta ต่อกันเป็นคำตอบ", async () => {
+  const a = make()
+  try {
+    const out = await a.sendPrompt(prompt())
+    assert.equal(out.result, "สวัสดีครับ", "delta สองก้อนต้องต่อกัน")
+    assert.equal(out.isError, undefined)
+  } finally { a.connection.close() }
+})
+
+test("framing ถูก แม้ stdout มาเป็นก้อนที่ไม่ตรงขอบ message", async () => {
+  // fake เขียนทีละ 7 ตัวอักษร — ถ้า framing ผิด JSON จะ parse ไม่ได้เลย
+  const a = make()
+  try {
+    for (let i = 0; i < 3; i++) {
+      assert.equal((await a.sendPrompt(prompt())).result, "สวัสดีครับ")
+    }
+  } finally { a.connection.close() }
+})
+
+test("thread ถูกใช้ซ้ำ ไม่สร้างใหม่ทุกข้อความ — นี่คือจุดต่างจาก v1 ที่ spawn ต่อ request", async () => {
+  const a = make()
+  try {
+    await a.sendPrompt(prompt())
+    const first = a.sessionInfo("line-c1")
+    await a.sendPrompt(prompt())
+    assert.deepEqual(a.sessionInfo("line-c1"), first, "thread id ต้องเท่าเดิม")
+  } finally { a.connection.close() }
+})
+
+test("sessionKey ต่างกันได้คนละ thread", async () => {
+  const a = make()
+  try {
+    await a.sendPrompt(prompt({ sessionKey: "line-c1" }))
+    await a.sendPrompt(prompt({ sessionKey: "line-u9" }))
+    assert.notEqual(a.sessionInfo("line-c1")!.threadId, a.sessionInfo("line-u9")!.threadId)
+  } finally { a.connection.close() }
+})
+
+test("turn/completed ที่ไม่มี delta → ดึงข้อความจาก items", async () => {
+  const a = make()
+  try {
+    assert.equal((await a.sendPrompt(prompt({ text: "NODELTA" }))).result, "จาก items")
+  } finally { a.connection.close() }
+})
+
+test("turn status error → isError และ core แปลงเป็นไทยได้", async () => {
+  const a = make()
+  try {
+    const out = await a.sendPrompt(prompt({ text: "ERROR" }))
+    assert.equal(out.isError, true)
+    const { toUserMessage } = await import("@botforge/core/errors")
+    assert.equal(toUserMessage(out.result), "เกิน rate limit ครับ รอสักครู่แล้วลองใหม่")
+  } finally { a.connection.close() }
+})
+
+test("timeout → timedOut ไม่ค้าง และ interrupt ถูกส่ง", async () => {
+  const a = make({ promptTimeoutMs: 150 })
+  try {
+    const out = await a.sendPrompt(prompt({ text: "SLOW" }))
+    assert.equal(out.timedOut, true)
+    assert.equal(out.result, "")
+  } finally { a.connection.close() }
+})
+
+test("auto-approve ตอบรับคำขออนุมัติให้อัตโนมัติ", async () => {
+  const a = make()
+  const seen: string[] = []
+  try {
+    await a.connection.ensureReady()
+    a.connection.rpc.on("approval/observed", (p: any) => seen.push(p.decision))
+    await a.sendPrompt(prompt({ text: "APPROVAL" }))
+    assert.deepEqual(seen, ["accept"], "v1 ตอบรับทุกคำขอ — ยกมาเหมือนเดิม")
+  } finally { a.connection.close() }
+})
+
+test("ปิด auto-approve แล้วไม่มีใครตอบ — คำขอค้างจนหมดเวลา", async () => {
+  const a = make({ autoApprove: false, promptTimeoutMs: 200 })
+  const seen: string[] = []
+  try {
+    await a.connection.ensureReady()
+    a.connection.rpc.on("approval/observed", (p: any) => seen.push(p.decision))
+    await a.sendPrompt(prompt({ text: "APPROVAL SLOW" }))
+    assert.deepEqual(seen, [], "ไม่มีใครอนุมัติ")
+  } finally { a.connection.close() }
+})
+
+test("/abort ส่ง turn/interrupt โดยไม่ทำลาย thread", async () => {
+  const a = make({ promptTimeoutMs: 2000 })
+  try {
+    await a.sendPrompt(prompt())
+    const before = a.sessionInfo("line-c1")!.threadId
+    assert.equal(a.abort("line-c1"), false, "ไม่มี turn เดินอยู่")
+    const slow = a.sendPrompt(prompt({ text: "SLOW" }))
+    await new Promise((r) => setTimeout(r, 60))
+    assert.equal(a.abort("line-c1"), true)
+    await slow
+    assert.equal(a.sessionInfo("line-c1")!.threadId, before, "thread ต้องยังอยู่")
+  } finally { a.connection.close() }
+})
+
+test("/new เปิด thread ใหม่ · /model เปลี่ยน model แล้วเปิด thread ใหม่", async () => {
+  const a = make()
+  try {
+    await a.sendPrompt(prompt())
+    const first = a.sessionInfo("line-c1")!.threadId
+    a.resetSession("line-c1")
+    assert.equal(a.sessionInfo("line-c1"), null)
+    await a.sendPrompt(prompt())
+    assert.notEqual(a.sessionInfo("line-c1")!.threadId, first)
+
+    a.setModel("line-c1", "o3")
+    assert.equal(a.modelOf("line-c1"), "o3")
+    await a.sendPrompt(prompt())
+    const info = a.sessionInfo("line-c1")!
+    assert.equal(info.model, "o3")
+    assert.ok(info.threadId.includes("o3"), "thread ใหม่ต้องผูกกับ model ใหม่")
+  } finally { a.connection.close() }
+})
+
+test("prompt prefix ตรงกับ v1 ของ codex — ไม่ใช่ของ opencode", () => {
+  const p = buildPrefix({
+    userContext: "[User: สมชาย]", groupName: "ทีมกฎหมาย",
+    quotedMessageId: "m-1", isGroup: true, now: new Date("2026-08-23T07:30:05Z"),
+  })
+  assert.ok(p.startsWith("[User: สมชาย] [Group: ทีมกฎหมาย] [Time: 2026-08-23 14:30:05+07:00]"))
+  assert.ok(p.includes("[Reply to message ID: m-1]"))
+  assert.ok(p.includes(GROUP_CHAT_INSTRUCTION))
+  assert.equal(p.includes("question tool"), false, "guard เป็นของ opencode ไม่ใช่ codex")
+})
+
+test("1:1 ไม่มี GROUP CHAT และไม่มี [Group:]", () => {
+  const p = buildPrefix({ isGroup: false, now: new Date("2026-08-23T07:30:05Z") })
+  assert.equal(p, "[Time: 2026-08-23 14:30:05+07:00]\n\n")
+})

--- a/packages/adapter-codex/src/adapter.ts
+++ b/packages/adapter-codex/src/adapter.ts
@@ -1,0 +1,216 @@
+/**
+ * CodexAdapter — RuntimePort บน `codex app-server`
+ *
+ * ต่างจาก `bot-service-codex` ของ v1 ตรงที่ **ไม่ spawn ต่อ request**
+ * app-server ตัวเดียวอยู่ยาว ถือ thread ไว้ เหมือนที่ opencode ทำกับ session
+ *
+ * ต่างจาก `bot-service-codex-appserver` ตรง transport — stdio ไม่ใช่ ws
+ */
+import type { PromptInput, RuntimeResult, RuntimePort } from "@botforge/core/router"
+import { AppServerConnection, DEFAULT_APPROVAL_POLICY, DEFAULT_SANDBOX_POLICY, type AppServerOptions } from "./appserver.ts"
+import { buildPrefix } from "./prompt.ts"
+
+export interface CodexAdapterOptions extends AppServerOptions {
+  model?: string
+  workspaceDir?: string
+  promptTimeoutMs?: number
+  approvalPolicy?: string
+  sandboxPolicy?: Record<string, unknown>
+  /**
+   * ตอบรับคำขออนุมัติ command/file ให้อัตโนมัติ — v1 ทำแบบนี้
+   * ปิดได้ แต่ถ้าปิดแล้วไม่มีใครตอบ turn จะค้างจนหมดเวลา
+   */
+  autoApprove?: boolean
+}
+
+interface ThreadState {
+  threadId: string
+  model: string
+}
+
+const DEFAULT_MODEL = "o4-mini"
+
+export class CodexAdapter implements RuntimePort {
+  readonly connection: AppServerConnection
+  readonly #threads = new Map<string, ThreadState>()
+  readonly #pendingModel = new Map<string, string>()
+  readonly #activeTurn = new Map<string, { threadId: string; turnId: string }>()
+  readonly #model: string
+  readonly #cwd: string
+  readonly #timeout: number
+  readonly #approvalPolicy: string
+  readonly #sandboxPolicy: Record<string, unknown>
+  readonly #autoApprove: boolean
+  readonly #log: (...args: unknown[]) => void
+
+  constructor(options: CodexAdapterOptions = {}) {
+    this.connection = new AppServerConnection(options)
+    this.#model = options.model ?? DEFAULT_MODEL
+    this.#cwd = options.workspaceDir ?? "/workspace"
+    this.#timeout = options.promptTimeoutMs ?? 300_000
+    this.#approvalPolicy = options.approvalPolicy ?? DEFAULT_APPROVAL_POLICY
+    this.#sandboxPolicy = options.sandboxPolicy ?? { ...DEFAULT_SANDBOX_POLICY }
+    this.#autoApprove = options.autoApprove ?? true
+    this.#log = options.log ?? (() => {})
+    if (this.#autoApprove) this.#wireAutoApproval()
+  }
+
+  /** v1 ตอบรับทุกคำขอ — ทำแบบเดียวกัน แต่แยกออกมาให้ปิดได้และเห็นชัดว่าทำอะไร */
+  #wireAutoApproval(): void {
+    for (const kind of ["commandExecution", "fileChange"] as const) {
+      this.connection.rpc.on(`item/${kind}/requestApproval`, (params: any) => {
+        if (!params?.itemId) return
+        this.#log(`อนุมัติ ${kind} อัตโนมัติ:`, params.itemId)
+        this.connection.rpc.notify(`item/${kind}/respondApproval`, {
+          threadId: params.threadId,
+          itemId: params.itemId,
+          decision: "accept",
+        })
+      })
+    }
+  }
+
+  // ── session (thread) ────────────────────────────────────────────────
+
+  modelOf(sessionKey: string): string {
+    return this.#threads.get(sessionKey)?.model ?? this.#pendingModel.get(sessionKey) ?? this.#model
+  }
+
+  /** `/model` — thread ของ Codex ผูกกับ model ตอนสร้าง จึงต้องเปิด thread ใหม่ */
+  setModel(sessionKey: string, model: string): void {
+    this.#threads.delete(sessionKey)
+    this.#pendingModel.set(sessionKey, model)
+  }
+
+  /** `/new` */
+  resetSession(sessionKey: string): void {
+    this.#threads.delete(sessionKey)
+  }
+
+  /** `/sessions` */
+  sessionInfo(sessionKey: string): { threadId: string; model: string } | null {
+    const t = this.#threads.get(sessionKey)
+    return t ? { threadId: t.threadId, model: t.model } : null
+  }
+
+  /**
+   * `/abort` — `turn/interrupt` เป็นการหยุด turn ที่กำลังเดิน **ไม่ทำลาย thread**
+   * ตรงกับ `cancellation: graceful` ของ `provider/v1/agent-provider`
+   */
+  abort(sessionKey: string): boolean {
+    const active = this.#activeTurn.get(sessionKey)
+    if (!active) return false
+    this.connection.rpc.notify("turn/interrupt", active)
+    return true
+  }
+
+  async #ensureThread(sessionKey: string): Promise<ThreadState> {
+    const existing = this.#threads.get(sessionKey)
+    if (existing) return existing
+
+    await this.connection.ensureReady()
+    const model = this.#pendingModel.get(sessionKey) ?? this.#model
+    const res = await this.connection.rpc.request("thread/start", {
+      model,
+      cwd: this.#cwd,
+      approvalPolicy: this.#approvalPolicy,
+      sandboxPolicy: this.#sandboxPolicy,
+    })
+    const threadId = res?.thread?.id
+    if (!threadId) throw new Error("thread/start ไม่คืน thread id")
+    this.#pendingModel.delete(sessionKey)
+    const state: ThreadState = { threadId, model }
+    this.#threads.set(sessionKey, state)
+    return state
+  }
+
+  // ── RuntimePort ─────────────────────────────────────────────────────
+
+  async sendPrompt(input: PromptInput): Promise<RuntimeResult> {
+    const thread = await this.#ensureThread(input.sessionKey)
+    const prefix = buildPrefix({
+      userContext: input.userContext,
+      groupName: input.groupName,
+      quotedMessageId: input.quotedMessageId,
+      isGroup: input.isGroup,
+    })
+
+    let text = ""
+    let turnId = ""
+    let errorMessage: string | null = null
+    const { promise, resolve } = Promise.withResolvers<void>()
+    const unsubs: Array<() => void> = []
+
+    unsubs.push(this.connection.rpc.on("turn/started", (p: any) => {
+      if (p?.turn?.id) {
+        turnId = p.turn.id
+        this.#activeTurn.set(input.sessionKey, { threadId: thread.threadId, turnId })
+      }
+    }))
+
+    unsubs.push(this.connection.rpc.on("item/agentMessage/delta", (p: any) => {
+      if (typeof p?.text === "string") text += p.text
+    }))
+
+    unsubs.push(this.connection.rpc.on("turn/completed", (p: any) => {
+      // delta อาจไม่มาเลย — ดึงข้อความสุดท้ายจาก items แทน
+      if (!text && Array.isArray(p?.turn?.items)) text = textFromItems(p.turn.items)
+      if (p?.turn?.status === "error") {
+        errorMessage = p?.turn?.codexErrorInfo?.message ?? "turn ล้มเหลว"
+      }
+      resolve()
+    }))
+
+    unsubs.push(this.connection.rpc.on("turn/failed", (p: any) => {
+      errorMessage = p?.error?.message ?? "turn ล้มเหลว"
+      resolve()
+    }))
+
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      if (turnId) this.connection.rpc.notify("turn/interrupt", { threadId: thread.threadId, turnId })
+      resolve()
+    }, this.#timeout)
+
+    try {
+      await this.connection.rpc.request("turn/start", {
+        threadId: thread.threadId,
+        input: [{ type: "text", text: prefix + input.text }],
+        model: thread.model,
+        cwd: this.#cwd,
+        approvalPolicy: this.#approvalPolicy,
+        sandboxPolicy: this.#sandboxPolicy,
+      })
+      await promise
+    } finally {
+      clearTimeout(timer)
+      for (const u of unsubs) u()
+      this.#activeTurn.delete(input.sessionKey)
+    }
+
+    if (timedOut) {
+      // ได้ข้อความบางส่วนก่อนหมดเวลา → ส่งให้ผู้ใช้พร้อมบอกว่ายังไม่ครบ (เหมือน opencode)
+      return text
+        ? { result: text, truncated: true, model: thread.model }
+        : { result: "", timedOut: true, model: thread.model }
+    }
+    if (errorMessage && !text) {
+      return { result: errorMessage, isError: true, model: thread.model }
+    }
+    return { result: text || "Done. (no text output)", model: thread.model }
+  }
+}
+
+function textFromItems(items: any[]): string {
+  for (const item of items) {
+    if (item?.type !== "agentMessage") continue
+    if (typeof item.text === "string" && item.text) return item.text
+    if (Array.isArray(item.content)) {
+      for (const part of item.content) {
+        if (part?.type === "output_text" && part.text) return part.text
+      }
+    }
+  }
+  return ""
+}

--- a/packages/adapter-codex/src/appserver.ts
+++ b/packages/adapter-codex/src/appserver.ts
@@ -1,0 +1,75 @@
+/**
+ * client ของ `codex app-server` — thread/turn API บน JSON-RPC 2.0
+ *
+ * โครง protocol ถอดมาจาก `bot-service-codex-appserver` ที่ v1-final ซึ่งพูดกับ
+ * app-server ตัวจริงได้ · ต่างกันที่ transport: ของเดิมใช้ WebSocket
+ * ส่วนตัวนี้ใช้ stdio ซึ่งเป็นทางที่ upstream รับประกัน
+ */
+import { JsonRpcClient, type LineTransport } from "./jsonrpc.ts"
+import { StdioTransport, type StdioOptions } from "./stdio.ts"
+
+/**
+ * ⚠️ **ค่าเริ่มต้นเปิดกว้างมาก — ยกมาจาก v1 ตามจริง ไม่ได้ตั้งใหม่**
+ *
+ * `bot-service-codex-appserver` ส่ง `approvalPolicy: "never"` +
+ * `sandboxPolicy: { type: "dangerFullAccess" }` และ auto-accept ทุกคำขออนุมัติ
+ * แปลว่า **ใครก็ตามที่พิมพ์ในกลุ่ม LINE สั่งให้ agent อ่าน/เขียนไฟล์อะไรก็ได้ใน workspace**
+ *
+ * ยกมาเหมือนเดิมเพื่อไม่เปลี่ยนพฤติกรรมเงียบ ๆ แต่เปิดให้ตั้งค่าได้
+ * และควรพิจารณาบีบให้แคบลงก่อนเอาไปใช้กับ bot ที่คนนอกเข้าถึงได้
+ */
+export const DEFAULT_APPROVAL_POLICY = "never"
+export const DEFAULT_SANDBOX_POLICY = { type: "dangerFullAccess" } as const
+
+export interface AppServerOptions extends StdioOptions {
+  /** ใส่ transport เองได้ — ใช้ตอน test หรือถ้าจะลอง ws (ซึ่ง upstream ไม่ซัพพอร์ต) */
+  transport?: LineTransport
+  requestTimeoutMs?: number
+  clientName?: string
+  clientVersion?: string
+  log?: (...args: unknown[]) => void
+}
+
+export class AppServerConnection {
+  readonly rpc: JsonRpcClient
+  readonly #log: (...args: unknown[]) => void
+  #ready: Promise<void> | undefined
+  #transport: LineTransport
+
+  constructor(options: AppServerOptions = {}) {
+    this.#log = options.log ?? (() => {})
+    this.#transport = options.transport ?? new StdioTransport(options)
+    this.rpc = new JsonRpcClient(this.#transport, {
+      requestTimeoutMs: options.requestTimeoutMs,
+      log: this.#log,
+    })
+    this.#name = options.clientName ?? "botforge-adapter-codex"
+    this.#version = options.clientVersion ?? "0.0.1"
+  }
+
+  readonly #name: string
+  readonly #version: string
+
+  /** handshake ครั้งเดียวต่อ connection — เรียกซ้ำได้ จะได้ promise เดิม */
+  ensureReady(): Promise<void> {
+    this.#ready ??= this.#handshake()
+    return this.#ready
+  }
+
+  async #handshake(): Promise<void> {
+    await this.rpc.request("initialize", {
+      clientInfo: { name: this.#name, title: "Botforge", version: this.#version },
+      capabilities: { experimentalApi: true },
+    })
+    this.rpc.notify("initialized")
+    this.#log("app-server พร้อมแล้ว")
+  }
+
+  get closed(): boolean {
+    return this.rpc.closed
+  }
+
+  close(): void {
+    this.rpc.close()
+  }
+}

--- a/packages/adapter-codex/src/e2e.test.ts
+++ b/packages/adapter-codex/src/e2e.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { fileURLToPath } from "node:url"
+import { CodexAdapter } from "./adapter.ts"
+import { runTurn, type TurnDeps } from "@botforge/core/router"
+import { SessionQueue } from "@botforge/core/session"
+import { ProfileCache, type LineProfileSource } from "@botforge/core/context"
+import { EventEmitter, MemorySink, BotforgeEvents, type TurnContext } from "@botforge/core/events"
+import { makePrincipal, toChannelId, resolveScope } from "@botforge/core/identity"
+
+const FAKE = fileURLToPath(new URL("./fixtures/fake-app-server.mjs", import.meta.url))
+const source: LineProfileSource = {
+  async getProfile() { return { displayName: "สมชาย" } },
+  async getGroupMemberProfile() { return { displayName: "สมชาย" } },
+  async getGroupSummary() { return { groupName: "ทีมกฎหมาย" } },
+}
+
+function harness(adapter: CodexAdapter) {
+  const sent: string[] = []
+  const sink = new MemorySink()
+  const scope = resolveScope({ BOTFORGE_TENANT_ID: "legal", BOTFORGE_WORKSPACE_ID: "legal-codex" })
+  const deps: TurnDeps = {
+    runtime: adapter,
+    transport: { async reply(_t, x) { sent.push(x) }, async push(_to, x) { sent.push(x) } },
+    queue: new SessionQueue(),
+    profiles: new ProfileCache(source),
+    events: new BotforgeEvents(new EventEmitter(scope, { sink })),
+  }
+  return { deps, sent, sink }
+}
+
+const newAdapter = () => new CodexAdapter({
+  command: process.execPath, args: [FAKE], workspaceDir: "/workspace", promptTimeoutMs: 3000,
+})
+
+const RAW_GROUP = "Ca56f9e2b1c3d4e5f6a7b8c9d0e1f2a3"
+const RAW_USER = "U4af4980629f1b2c3d4e5f6a7b8c9d0e1"
+
+test("e2e — LINE → codex app-server → LINE ผ่าน core ตัวเดียวกับ opencode", async () => {
+  const adapter = newAdapter()
+  const { deps, sent, sink } = harness(adapter)
+  try {
+    const channelId = toChannelId("line", RAW_GROUP)
+    const ctx: TurnContext = {
+      executionId: "exec-codex-1", channelId, channelType: "line",
+      actor: makePrincipal("line", RAW_USER, "สมชาย"),
+    }
+    const out = await runTurn(deps, {
+      sessionKey: channelId, userId: RAW_USER, text: "ช่วยดู docker compose หน่อย",
+      replyToken: "T", isGroup: true, groupId: RAW_GROUP, ctx, runtimeName: "codex",
+    })
+    assert.equal(out.kind, "answered")
+    assert.deepEqual(sent, ["สวัสดีครับ"])
+
+    // audit event ชุดเดียวกับ opencode — core ไม่รู้ว่า runtime เป็นตัวไหน
+    assert.deepEqual(sink.events.map((e) => e.event_type),
+      ["STATE_TRANSITION", "EXECUTION_STARTED", "STATE_TRANSITION"])
+    assert.equal(sink.events.at(-1)!.channel_id, "line-ca56f9e2b1c3d4e5f6a7b8c9d0e1f2a3")
+  } finally { adapter.connection.close() }
+})
+
+test("e2e — error ของ codex ถูกแปลงเป็นไทยด้วย error/v1 ตัวเดียวกัน", async () => {
+  const adapter = newAdapter()
+  const { deps, sent } = harness(adapter)
+  try {
+    const out = await runTurn(deps, {
+      sessionKey: "line-u1", userId: RAW_USER, text: "ERROR", replyToken: "T", isGroup: false,
+    })
+    assert.equal(out.kind, "answered")
+    assert.deepEqual(sent, ["เกิน rate limit ครับ รอสักครู่แล้วลองใหม่"])
+  } finally { adapter.connection.close() }
+})
+
+test("e2e — คิวของ core บังคับให้เทิร์นเดียวกันรันทีละตัว", async () => {
+  const adapter = newAdapter()
+  const { deps } = harness(adapter)
+  try {
+    const key = "line-u2"
+    const results = await Promise.all([
+      runTurn(deps, { sessionKey: key, userId: RAW_USER, text: "หนึ่ง", isGroup: false }),
+      runTurn(deps, { sessionKey: key, userId: RAW_USER, text: "สอง", isGroup: false }),
+    ])
+    assert.deepEqual(results.map((r) => r.kind), ["answered", "answered"])
+    // ทั้งสองเทิร์นใช้ thread เดียวกัน = ไม่ได้แข่งกันสร้าง thread
+    assert.ok(adapter.sessionInfo(key))
+  } finally { adapter.connection.close() }
+})

--- a/packages/adapter-codex/src/fixtures/fake-app-server.mjs
+++ b/packages/adapter-codex/src/fixtures/fake-app-server.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * app-server ปลอมสำหรับ test — พูด JSON-RPC 2.0 บน stdio เหมือนของจริง
+ *
+ * จงใจเขียน stdout เป็นก้อนที่ **ไม่ตรงขอบ message** เพื่อพิสูจน์ว่า
+ * StdioTransport ต่อเศษบรรทัดถูก · ของจริงก็ไม่รับประกันว่า chunk จะตรงขอบ
+ */
+let buffer = ""
+let turnSeq = 0
+
+function writeChunked(text) {
+  // แบ่งเป็นชิ้นละ 7 ตัวอักษร — JSON ขาดกลางแน่นอน
+  for (let i = 0; i < text.length; i += 7) process.stdout.write(text.slice(i, i + 7))
+}
+const send = (obj) => writeChunked(JSON.stringify(obj) + "\n")
+const result = (id, r) => send({ jsonrpc: "2.0", id, result: r })
+const notify = (method, params) => send({ jsonrpc: "2.0", method, params })
+
+process.stdout.write("app-server starting, not json\n")   // log ปนมาทาง stdout
+
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", (chunk) => {
+  buffer += chunk
+  let i
+  while ((i = buffer.indexOf("\n")) >= 0) {
+    const line = buffer.slice(0, i); buffer = buffer.slice(i + 1)
+    if (!line.trim()) continue
+    let msg
+    try { msg = JSON.parse(line) } catch { continue }
+    handle(msg)
+  }
+})
+
+function handle(msg) {
+  const { id, method, params } = msg
+  switch (method) {
+    case "initialize":
+      return result(id, { serverInfo: { name: "fake-app-server", version: "0.0.0" } })
+    case "initialized":
+      return
+    case "thread/start":
+      return result(id, { thread: { id: `thr-${params.model}-${++turnSeq}` } })
+    case "turn/start": {
+      result(id, { accepted: true })
+      const turnId = `turn-${turnSeq}`
+      const text = params.input?.[0]?.text ?? ""
+      setTimeout(() => notify("turn/started", { turn: { id: turnId } }), 1)
+      if (text.includes("SLOW")) return                       // ไม่จบเลย → ทดสอบ timeout
+      if (text.includes("APPROVAL")) {
+        setTimeout(() => notify("item/commandExecution/requestApproval", {
+          threadId: params.threadId, itemId: "item-1",
+        }), 2)
+      }
+      setTimeout(() => {
+        if (text.includes("NODELTA")) {
+          notify("turn/completed", { turn: { id: turnId, status: "completed",
+            items: [{ type: "agentMessage", content: [{ type: "output_text", text: "จาก items" }] }] } })
+        } else if (text.includes("ERROR")) {
+          notify("turn/completed", { turn: { id: turnId, status: "error",
+            codexErrorInfo: { message: "429 rate limit exceeded" } } })
+        } else {
+          notify("item/agentMessage/delta", { text: "สวัสดี" })
+          notify("item/agentMessage/delta", { text: "ครับ" })
+          notify("turn/completed", { turn: { id: turnId, status: "completed" } })
+        }
+      }, 5)
+      return
+    }
+    case "item/commandExecution/respondApproval":
+      return notify("approval/observed", { decision: params.decision })
+    case "turn/interrupt":
+      return notify("turn/completed", { turn: { id: params.turnId, status: "aborted" } })
+    default:
+      if (id !== undefined) send({ jsonrpc: "2.0", id, error: { code: -32601, message: `ไม่รู้จัก method ${method}` } })
+  }
+}

--- a/packages/adapter-codex/src/index.ts
+++ b/packages/adapter-codex/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./jsonrpc.ts"
+export * from "./stdio.ts"
+export * from "./appserver.ts"
+export * from "./prompt.ts"
+export * from "./adapter.ts"

--- a/packages/adapter-codex/src/jsonrpc.test.ts
+++ b/packages/adapter-codex/src/jsonrpc.test.ts
@@ -1,0 +1,110 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { JsonRpcClient, RpcError, RpcClosedError, type LineTransport } from "./jsonrpc.ts"
+
+function fake() {
+  const sent: any[] = []
+  let onLine: (l: string) => void = () => {}
+  let onClose: (r?: string) => void = () => {}
+  const t: LineTransport = {
+    send: (line) => sent.push(JSON.parse(line)),
+    onLine: (h) => { onLine = h },
+    onClose: (h) => { onClose = h },
+    close: () => {},
+  }
+  return {
+    transport: t, sent,
+    reply: (id: number, result: unknown) => onLine(JSON.stringify({ jsonrpc: "2.0", id, result })),
+    fail: (id: number, code: number, message: string) => onLine(JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } })),
+    notify: (method: string, params: unknown) => onLine(JSON.stringify({ jsonrpc: "2.0", method, params })),
+    raw: (line: string) => onLine(line),
+    kill: (reason?: string) => onClose(reason),
+  }
+}
+
+test("request ได้ผลกลับตาม id", async () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport)
+  const p = c.request("thread/start", { model: "o4-mini" })
+  assert.deepEqual(f.sent[0], { jsonrpc: "2.0", id: 1, method: "thread/start", params: { model: "o4-mini" } })
+  f.reply(1, { thread: { id: "t1" } })
+  assert.deepEqual(await p, { thread: { id: "t1" } })
+})
+
+test("หลาย request พร้อมกันจับคู่ id ถูก ไม่สลับ", async () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport)
+  const a = c.request("a"), b = c.request("b")
+  f.reply(2, "ผลของ b")          // ตอบสลับลำดับ
+  f.reply(1, "ผลของ a")
+  assert.equal(await a, "ผลของ a")
+  assert.equal(await b, "ผลของ b")
+})
+
+test("error จาก server กลายเป็น RpcError พร้อม code", async () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport)
+  const p = c.request("nope")
+  f.fail(1, -32601, "ไม่รู้จัก method")
+  await assert.rejects(p, (e: any) => e instanceof RpcError && e.code === -32601)
+})
+
+test("notification เรียก handler ที่ subscribe ไว้", () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport)
+  const got: string[] = []
+  const off = c.on("item/agentMessage/delta", (p) => got.push(p.text))
+  f.notify("item/agentMessage/delta", { text: "ก" })
+  f.notify("item/agentMessage/delta", { text: "ข" })
+  off()
+  f.notify("item/agentMessage/delta", { text: "ค" })
+  assert.deepEqual(got, ["ก", "ข"], "หลัง off ต้องไม่ได้รับอีก")
+})
+
+test("handler ตัวหนึ่งพังไม่ทำให้ตัวอื่นไม่ได้รับ", () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport)
+  const got: string[] = []
+  c.on("x", () => { throw new Error("พัง") })
+  c.on("x", () => got.push("ได้รับ"))
+  f.notify("x", {})
+  assert.deepEqual(got, ["ได้รับ"])
+})
+
+test("บรรทัดที่ไม่ใช่ JSON ถูกข้าม ไม่ทำให้พัง — app-server เขียน log ปน stdout ได้", () => {
+  const f = fake()
+  const logs: string[] = []
+  const c = new JsonRpcClient(f.transport, { log: (...a) => logs.push(a.map(String).join(" ")) })
+  const got: unknown[] = []
+  c.on("ping", (p) => got.push(p))
+  assert.doesNotThrow(() => f.raw("app-server starting, not json"))
+  assert.doesNotThrow(() => f.raw(""))
+  f.notify("ping", { ok: true })
+  assert.deepEqual(got, [{ ok: true }])
+  assert.ok(logs.some((l) => l.includes("ไม่ใช่ JSON")))
+})
+
+test("transport ปิด → pending ทุกตัวถูก reject ไม่ค้าง", async () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport)
+  const a = c.request("a"), b = c.request("b")
+  f.kill("app-server ตาย")
+  await assert.rejects(a, RpcClosedError)
+  await assert.rejects(b, RpcClosedError)
+  assert.equal(c.closed, true)
+  await assert.rejects(c.request("c"), RpcClosedError)
+})
+
+test("timeout ของ request แยกจาก timeout ของ turn", async () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport, { requestTimeoutMs: 20 })
+  await assert.rejects(c.request("ช้า"), /หมดเวลา/)
+})
+
+test("notify ไม่สร้าง id และไม่รอผล", () => {
+  const f = fake()
+  const c = new JsonRpcClient(f.transport)
+  c.notify("initialized")
+  assert.deepEqual(f.sent[0], { jsonrpc: "2.0", method: "initialized", params: {} })
+  assert.equal("id" in f.sent[0], false, "notification ต้องไม่มี id")
+})

--- a/packages/adapter-codex/src/jsonrpc.ts
+++ b/packages/adapter-codex/src/jsonrpc.ts
@@ -1,0 +1,152 @@
+/**
+ * JSON-RPC 2.0 client แบบ line-delimited — ไม่ผูกกับ transport
+ *
+ * `codex app-server` พูด JSON-RPC 2.0 หนึ่ง message ต่อบรรทัด
+ * แยก transport ออกมาเพราะ upstream มีสองทาง และคุณภาพต่างกันมาก:
+ *
+ *   stdio                      ✅ stable · production-ready
+ *   --listen ws://…            ⚠️ upstream ระบุเองว่า "Experimental, unsupported"
+ *
+ * v1 (`bot-service-codex-appserver`) ใช้ ws · adapter นี้ใช้ stdio เป็นค่าเริ่มต้น
+ */
+
+/** สิ่งที่ client ต้องการจากช่องทางสื่อสาร — หนึ่งบรรทัดคือหนึ่ง message */
+export interface LineTransport {
+  send(line: string): void
+  onLine(handler: (line: string) => void): void
+  onClose(handler: (reason?: string) => void): void
+  close(): void
+}
+
+export class RpcError extends Error {
+  readonly code: number
+  readonly data: unknown
+  constructor(code: number, message: string, data?: unknown) {
+    super(message)
+    this.name = "RpcError"
+    this.code = code
+    this.data = data
+  }
+}
+
+export class RpcClosedError extends Error {
+  constructor(reason?: string) {
+    super(reason ? `การเชื่อมต่อปิดลง: ${reason}` : "การเชื่อมต่อปิดลง")
+    this.name = "RpcClosedError"
+  }
+}
+
+type Pending = { resolve: (v: unknown) => void; reject: (e: Error) => void; timer?: ReturnType<typeof setTimeout> }
+
+export interface RpcOptions {
+  /** timeout ต่อ request — 0 = ไม่ตั้ง */
+  requestTimeoutMs?: number
+  log?: (...args: unknown[]) => void
+}
+
+export class JsonRpcClient {
+  readonly #transport: LineTransport
+  readonly #pending = new Map<number, Pending>()
+  readonly #handlers = new Map<string, Set<(params: any) => void>>()
+  readonly #timeout: number
+  readonly #log: (...args: unknown[]) => void
+  #nextId = 0
+  #closed = false
+
+  constructor(transport: LineTransport, options: RpcOptions = {}) {
+    this.#transport = transport
+    this.#timeout = options.requestTimeoutMs ?? 300_000
+    this.#log = options.log ?? (() => {})
+    transport.onLine((line) => this.#onLine(line))
+    transport.onClose((reason) => this.#onClose(reason))
+  }
+
+  get closed(): boolean {
+    return this.#closed
+  }
+
+  /** ฟัง notification ที่ server ส่งมาเอง · คืนฟังก์ชันสำหรับเลิกฟัง */
+  on(method: string, handler: (params: any) => void): () => void {
+    let set = this.#handlers.get(method)
+    if (!set) this.#handlers.set(method, (set = new Set()))
+    set.add(handler)
+    return () => { set!.delete(handler) }
+  }
+
+  request(method: string, params: Record<string, unknown> = {}): Promise<any> {
+    if (this.#closed) return Promise.reject(new RpcClosedError())
+    const id = ++this.#nextId
+    return new Promise((resolve, reject) => {
+      const entry: Pending = { resolve, reject }
+      if (this.#timeout > 0) {
+        entry.timer = setTimeout(() => {
+          if (this.#pending.delete(id)) reject(new Error(`request ${method} หมดเวลา`))
+        }, this.#timeout)
+      }
+      this.#pending.set(id, entry)
+      try {
+        this.#transport.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }))
+      } catch (err) {
+        this.#settle(id, undefined, err instanceof Error ? err : new Error(String(err)))
+      }
+    })
+  }
+
+  notify(method: string, params: Record<string, unknown> = {}): void {
+    if (this.#closed) return
+    this.#transport.send(JSON.stringify({ jsonrpc: "2.0", method, params }))
+  }
+
+  close(): void {
+    this.#transport.close()
+    this.#onClose("ปิดโดยผู้เรียก")
+  }
+
+  #settle(id: number, result?: unknown, error?: Error): void {
+    const entry = this.#pending.get(id)
+    if (!entry) return
+    this.#pending.delete(id)
+    if (entry.timer) clearTimeout(entry.timer)
+    if (error) entry.reject(error)
+    else entry.resolve(result)
+  }
+
+  #onLine(line: string): void {
+    const trimmed = line.trim()
+    if (!trimmed) return
+    let msg: any
+    try {
+      msg = JSON.parse(trimmed)
+    } catch {
+      // app-server เขียน log ปนมาทาง stdout ได้ — บรรทัดที่ไม่ใช่ JSON ไม่ใช่ error
+      this.#log("ข้ามบรรทัดที่ไม่ใช่ JSON:", trimmed.slice(0, 120))
+      return
+    }
+
+    if (msg.id !== undefined && this.#pending.has(msg.id)) {
+      if (msg.error) {
+        const e = msg.error
+        this.#settle(msg.id, undefined, new RpcError(e.code ?? -1, e.message ?? JSON.stringify(e), e.data))
+      } else {
+        this.#settle(msg.id, msg.result)
+      }
+      return
+    }
+
+    if (typeof msg.method === "string") {
+      const handlers = this.#handlers.get(msg.method)
+      if (!handlers) return
+      for (const h of [...handlers]) {
+        // handler ตัวหนึ่งพังต้องไม่ทำให้ตัวอื่นไม่ได้รับ
+        try { h(msg.params) } catch (err) { this.#log("notification handler พัง:", err) }
+      }
+    }
+  }
+
+  #onClose(reason?: string): void {
+    if (this.#closed) return
+    this.#closed = true
+    for (const [id] of this.#pending) this.#settle(id, undefined, new RpcClosedError(reason))
+    this.#handlers.clear()
+  }
+}

--- a/packages/adapter-codex/src/prompt.ts
+++ b/packages/adapter-codex/src/prompt.ts
@@ -1,0 +1,36 @@
+/**
+ * ประกอบ prompt prefix แบบ Codex
+ *
+ * ยกมาจาก `sendPrompt()` ของ `bot-service-codex` ที่ v1-final ทุกตัวอักษร
+ *
+ * ⚠️ **ต่างจาก opencode จริง ๆ** ไม่ใช่แค่จัดบรรทัดต่างกัน:
+ *   · ไม่มี question-tool guard (เป็นของ opencode ตัวเดียว)
+ *   · ใส่ `[Group: ชื่อ]` เข้า prompt — opencode ไม่ใส่ (ไม่มี getGroupName ด้วยซ้ำ)
+ *   · reply ใช้ `[Reply to message ID: x]` ส่วน opencode ใช้ประโยคยาวกว่า
+ *   · user/group/time อยู่บรรทัดเดียวกันคั่นด้วยช่องว่าง ไม่ใช่ย่อหน้าละบล็อก
+ *
+ * นี่คือเหตุผลที่ core ส่งแค่วัตถุดิบมาให้ แล้วให้ adapter ประกอบเอง
+ */
+import { getTimeContext } from "@botforge/core/context"
+
+export const GROUP_CHAT_INSTRUCTION =
+  "[GROUP CHAT: You are in a group chat. If this message is clearly NOT directed at you (just people chatting with each other, unrelated conversations), respond with exactly [SKIP] and nothing else. If the message mentions you, asks a question, or could be directed at you, respond normally.]"
+
+export interface PrefixInput {
+  userContext?: string
+  groupName?: string
+  quotedMessageId?: string
+  isGroup: boolean
+  now?: Date
+}
+
+/** ลำดับ: `{user} [Group: x] {time}\n\n[Reply…]\n\n[GROUP CHAT…]\n\n` */
+export function buildPrefix(input: PrefixInput): string {
+  let out = ""
+  if (input.userContext) out += `${input.userContext} `
+  if (input.groupName) out += `[Group: ${input.groupName}] `
+  out += `${getTimeContext(input.now)}\n\n`
+  if (input.quotedMessageId) out += `[Reply to message ID: ${input.quotedMessageId}]\n\n`
+  if (input.isGroup) out += `${GROUP_CHAT_INSTRUCTION}\n\n`
+  return out
+}

--- a/packages/adapter-codex/src/stdio.ts
+++ b/packages/adapter-codex/src/stdio.ts
@@ -1,0 +1,95 @@
+/**
+ * transport แบบ stdio — spawn `codex app-server` ครั้งเดียวแล้วคุยผ่าน stdin/stdout
+ *
+ * นี่คือ transport ที่ upstream ระบุว่า stable · ต่างจาก `--listen ws://…`
+ * ที่เอกสารของ Codex เขียนเองว่า "Experimental, unsupported"
+ * (v1 `bot-service-codex-appserver` ใช้ ws — ดู README)
+ *
+ * process อยู่ยาวตลอดอายุ adapter ไม่ได้ spawn ใหม่ทุก request แบบ
+ * `bot-service-codex` ที่เรียก `spawn("codex", …)` ต่อหนึ่งข้อความ
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import type { LineTransport } from "./jsonrpc.ts"
+
+export interface StdioOptions {
+  command?: string
+  args?: string[]
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  /** stderr ของ app-server — ไม่ใช่ช่องทาง protocol แต่มี log ที่ต้องดูตอน debug */
+  onStderr?: (chunk: string) => void
+  onExit?: (code: number | null, signal: string | null) => void
+}
+
+export class StdioTransport implements LineTransport {
+  readonly child: ChildProcessWithoutNullStreams
+  #buffer = ""
+  #lineHandler: ((line: string) => void) | undefined
+  #closeHandler: ((reason?: string) => void) | undefined
+  #closed = false
+
+  constructor(options: StdioOptions = {}) {
+    const command = options.command ?? "codex"
+    const args = options.args ?? ["app-server"]
+    this.child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+
+    this.child.stdout.setEncoding("utf8")
+    this.child.stdout.on("data", (chunk: string) => this.#onChunk(chunk))
+
+    this.child.stderr.setEncoding("utf8")
+    this.child.stderr.on("data", (chunk: string) => options.onStderr?.(chunk))
+
+    this.child.on("exit", (code, signal) => {
+      options.onExit?.(code, signal)
+      this.#fireClose(`app-server จบการทำงาน (code=${code} signal=${signal})`)
+    })
+    this.child.on("error", (err) => this.#fireClose(`spawn ไม่สำเร็จ: ${err.message}`))
+  }
+
+  /**
+   * framing เป็น newline-delimited — chunk ที่ได้จาก stdout ไม่ตรงกับขอบ message
+   * ต้องเก็บเศษไว้ต่อกับ chunk ถัดไป ไม่งั้น JSON จะขาดกลาง
+   */
+  #onChunk(chunk: string): void {
+    this.#buffer += chunk
+    let index: number
+    while ((index = this.#buffer.indexOf("\n")) >= 0) {
+      const line = this.#buffer.slice(0, index)
+      this.#buffer = this.#buffer.slice(index + 1)
+      if (line.trim()) this.#lineHandler?.(line)
+    }
+  }
+
+  send(line: string): void {
+    if (this.#closed) throw new Error("transport ปิดแล้ว")
+    this.child.stdin.write(line + "\n")
+  }
+
+  onLine(handler: (line: string) => void): void {
+    this.#lineHandler = handler
+  }
+
+  onClose(handler: (reason?: string) => void): void {
+    this.#closeHandler = handler
+  }
+
+  close(): void {
+    if (this.#closed) return
+    this.child.stdin.end()
+    this.child.kill("SIGTERM")
+    // ไม่ยอมตายใน 3 วิ ค่อยบังคับ — เหมือนที่ v1 ทำกับ spawn ต่อ request
+    const t = setTimeout(() => { if (!this.child.killed) this.child.kill("SIGKILL") }, 3000)
+    t.unref?.()
+    this.#fireClose("ปิดโดยผู้เรียก")
+  }
+
+  #fireClose(reason: string): void {
+    if (this.#closed) return
+    this.#closed = true
+    this.#closeHandler?.(reason)
+  }
+}

--- a/packages/adapter-codex/tsconfig.json
+++ b/packages/adapter-codex/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2024"
+    ],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -60,7 +60,7 @@ npm run typecheck --prefix packages/core
 > เปลี่ยน Codex → Claude โดยไม่แก้ Channel ✅ — runtime อยู่หลัง `RuntimePort` ตัวเดียว
 > เปลี่ยน LINE → Web โดยไม่แก้ Runtime · ⬜ — `LineTransport` แยกแล้ว แต่ยังไม่มี channel ที่สอง
 
-adapter ตัวแรกอยู่ที่ [`@botforge/adapter-opencode`](../adapter-opencode/) —
+adapter ที่มีแล้ว: [`adapter-opencode`](../adapter-opencode/) · [`adapter-codex`](../adapter-codex/) —
 พิสูจน์แล้วด้วย `e2e.test.ts` ที่วิ่งผ่าน HTTP จริง และ `scripts/smoke-opencode.ts`
 ที่ยิง OpenCode server จริงได้ด้วย model ฟรี
 

--- a/scripts/smoke-codex.ts
+++ b/scripts/smoke-codex.ts
@@ -1,0 +1,84 @@
+/**
+ * ยิง `codex app-server` จริงผ่าน @botforge/core + @botforge/adapter-codex
+ *
+ *   node --experimental-strip-types scripts/smoke-codex.ts "คำถามของคุณ"
+ *
+ * ต้องมี codex CLI ในเครื่อง (`npm i -g @openai/codex`) และล็อกอินแล้ว
+ * ไม่ต้องมี LINE — transport พิมพ์ลง stdout แทน
+ *
+ * ใส่ BOTFORGE_CODEX_FAKE=1 เพื่อใช้ app-server ปลอมใน fixtures (ไม่ต้องมี codex)
+ */
+import { fileURLToPath } from "node:url"
+import { CodexAdapter } from "@botforge/adapter-codex"
+import { runTurn, type TurnDeps } from "@botforge/core/router"
+import { SessionQueue } from "@botforge/core/session"
+import { ProfileCache, type LineProfileSource } from "@botforge/core/context"
+import { EventEmitter, MemorySink, BotforgeEvents, type TurnContext } from "@botforge/core/events"
+import { makePrincipal, toChannelId, resolveScope } from "@botforge/core/identity"
+
+const useFake = process.env.BOTFORGE_CODEX_FAKE === "1"
+const model = process.env.CODEX_MODEL ?? "o4-mini"
+const text = process.argv.slice(2).join(" ") || "สวัสดีครับ ช่วยแนะนำตัวสั้น ๆ หน่อย"
+const fakePath = fileURLToPath(new URL("../packages/adapter-codex/src/fixtures/fake-app-server.mjs", import.meta.url))
+
+console.log(`transport : stdio (codex app-server)${useFake ? "  [FAKE]" : ""}`)
+console.log(`model     : ${model}`)
+console.log(`workspace : ${process.env.WORKSPACE_DIR ?? "/workspace"}`)
+console.log(`prompt    : ${text}\n`)
+
+const adapter = new CodexAdapter({
+  command: useFake ? process.execPath : (process.env.CODEX_BIN ?? "codex"),
+  args: useFake ? [fakePath] : ["app-server"],
+  model,
+  workspaceDir: process.env.WORKSPACE_DIR ?? "/workspace",
+  promptTimeoutMs: Number(process.env.PROMPT_TIMEOUT_MS ?? 300_000),
+  log: (...a) => console.log("  [adapter]", ...a),
+  onStderr: (c) => process.stderr.write(`  [app-server] ${c}`),
+})
+
+const scope = resolveScope({
+  BOTFORGE_TENANT_ID: process.env.BOTFORGE_TENANT_ID ?? "smoke",
+  BOTFORGE_WORKSPACE_ID: process.env.BOTFORGE_WORKSPACE_ID ?? "smoke-codex",
+})
+const sink = new MemorySink()
+const profileSource: LineProfileSource = {
+  async getProfile() { return { displayName: "ผู้ทดสอบ" } },
+  async getGroupMemberProfile() { return { displayName: "ผู้ทดสอบ" } },
+  async getGroupSummary() { return { groupName: "smoke test" } },
+}
+
+const rawUserId = "U0000000000000000000000000smoke1"
+const channelId = toChannelId("line", rawUserId)
+const deps: TurnDeps = {
+  runtime: adapter,
+  transport: {
+    async reply(_t, t) { console.log("─── ตอบกลับ (reply) ───\n" + t + "\n") },
+    async push(_to, t) { console.log("─── ตอบกลับ (push) ───\n" + t + "\n") },
+  },
+  queue: new SessionQueue(),
+  profiles: new ProfileCache(profileSource),
+  events: new BotforgeEvents(new EventEmitter(scope, { sink })),
+  log: (...a) => console.log("  [core]", ...a),
+}
+const ctx: TurnContext = {
+  executionId: "exec-smoke-codex-1", channelId, channelType: "line",
+  actor: makePrincipal("line", rawUserId, "ผู้ทดสอบ"),
+}
+
+const started = performance.now()
+const out = await runTurn(deps, {
+  sessionKey: channelId, userId: rawUserId, text,
+  replyToken: "SMOKE_TOKEN", isGroup: false, ctx, runtimeName: "codex",
+})
+const ms = Math.round(performance.now() - started)
+
+console.log(`ผลลัพธ์  : ${out.kind}  (${ms} ms)`)
+if (out.kind === "failed") console.log(`error   : ${out.error.code} · ${out.error.message}`)
+console.log(`thread  : ${JSON.stringify(adapter.sessionInfo(channelId))}`)
+console.log(`\naudit event ${sink.events.length} ใบ:`)
+for (const e of sink.events) {
+  const t = e.transition ? ` ${e.transition.from} → ${e.transition.to}` : ""
+  console.log(`  ${String(e.sequence).padStart(2)} ${e.event_type}${t}`)
+}
+adapter.connection.close()
+process.exit(out.kind === "answered" ? 0 : 1)


### PR DESCRIPTION
adapter ตัวที่สอง — ยุบ `codex` กับ `codex-appserver` เป็นตัวเดียวบน **stdio** transport

ตรงกับ Q3 ที่ตัดสินไว้ว่ายุบได้ และตรงกับที่ [`current-state.md`](../blob/v2/docs/architecture/current-state.md) §2.1 วัดได้ว่าฝั่ง bot ของสองตัวนี้ **เหมือนกันทุก byte**

## ทำไม stdio ไม่ใช่ ws

`codex app-server` มีสอง transport และคุณภาพต่างกันชัด:

| transport | upstream ว่าไง |
| --- | --- |
| **stdio** | ✅ stable · production-ready · ทางที่ VS Code extension และ Python SDK ใช้ |
| `--listen ws://…` | ⚠️ **"Experimental, unsupported"** |

v1 เลือกทางหลัง — `bot-service-codex-appserver/server/entrypoint.sh` รัน `codex app-server --listen "ws://0.0.0.0:$PORT"` ซึ่งเป็นตัวที่ upstream เขียนเองว่าไม่ซัพพอร์ต · template นั้นมี **0 project ใช้จริง** จาก 14

ส่วน `bot-service-codex` เรียก `spawn("codex")` **ทุก request** — ไม่มี process อยู่ยาว

adapter นี้เอาข้อดีของ app-server (process อยู่ยาว ถือ thread) มาวางบน transport ที่ upstream รับประกัน

## protocol

```
initialize / initialized              handshake ครั้งเดียวต่อ connection
thread/start  → {thread:{id}}         thread ต่อ sessionKey
turn/start
  ← turn/started · item/agentMessage/delta · turn/completed
  ← item/*/requestApproval → item/*/respondApproval
turn/interrupt                        /abort และ timeout — ไม่ทำลาย thread
```

`turn/interrupt` = `cancellation: graceful` ตาม `provider/v1/agent-provider` — ต่างจาก `gocode` ที่ `/abort` ไปลบ session ทิ้ง

## ⚠️ ค่าเริ่มต้นเปิดกว้างมาก — ยกมาจาก v1 ตามจริง

```
approvalPolicy "never" · sandboxPolicy dangerFullAccess · autoApprove true
```

ในบริบท LINE bot แปลว่า **ใครพิมพ์ในกลุ่มก็สั่งให้ agent อ่าน/เขียนไฟล์อะไรก็ได้ใน workspace**

ยกมาเหมือนเดิมเพื่อไม่เปลี่ยนพฤติกรรมเงียบ ๆ แต่เปิดให้ตั้งค่าได้ และเขียนเตือนไว้ใน README — **ควรตัดสินใจเรื่องนี้ก่อนเอาไปใช้จริง**

## test — 25 ตัว คุยกับ child process จริง

ไม่ใช่ mock ของ `spawn` · `fixtures/fake-app-server.mjs` พูด JSON-RPC เหมือนของจริง และจงใจ:

- เขียน stdout **เป็นก้อนละ 7 ตัวอักษร** → พิสูจน์ว่า framing ต่อเศษบรรทัดถูก
- เขียน **log ที่ไม่ใช่ JSON ปนมาทาง stdout** → พิสูจน์ว่า client ข้ามได้ไม่พัง

## `runtime-matrix.md`

ปิด deliverable ที่ค้างจาก Phase 0 — สำรวจว่า engine ไหนมี server mode แล้ว

| CLI | สถานะ |
| --- | --- |
| Codex `app-server` | ✅ พร้อมใช้ |
| Qwen Code `qwen serve` | ⚠️ มีแล้วแต่ experimental |
| Gemini CLI daemon | ❌ [PR #20700](https://github.com/google-gemini/gemini-cli/pull/20700) ยังไม่ merge |

> ผลค้นหาเว็บสรุปว่า Gemini CLI *"has introduced daemon mode"* — ไม่จริง ต้องเปิด PR ดูเองถึงเห็นว่ายังค้าง

## ยังไม่ได้ทำ

ยังไม่ได้ยิง `codex app-server` ตัวจริง — เครื่องพัฒนาไม่มี codex CLI
โครง protocol ถอดมาจาก `bot-service-codex-appserver` ที่ v1 เขียนไว้และพูดกับของจริงได้

---

174 test (core 111 + opencode 38 + codex 25) · typecheck สะอาด · conformance ผ่าน
