### PR TITLE
fix(adapter-codex): turn/completed ของ turn เก่าไม่ปิดเทิร์นถัดไป

### DIFF
--- a/packages/adapter-codex/README.md
+++ b/packages/adapter-codex/README.md
@@ -89,6 +89,23 @@ npm test --prefix packages/adapter-codex
 เพื่อพิสูจน์ว่า framing ต่อเศษบรรทัดถูก — ของจริงก็ไม่รับประกันว่า chunk จะตรงขอบ message
 กับ **เขียน log ที่ไม่ใช่ JSON ปนมาทาง stdout** เพราะ app-server จริงก็ทำ
 
+## bug ที่เจอจากการรันจริง — `turn/completed` ของ turn เก่า
+
+`turn/interrupt` ไม่ได้ทำให้ turn หายไปเงียบ ๆ — app-server ส่ง `turn/completed`
+ของ turn นั้นตามมาทีหลัง และใบนั้น**อาจมาถึงตอนที่เทิร์นถัดไปเริ่มไปแล้ว**
+
+อาการ: เทิร์นหลังจาก timeout จบทันทีใน 1 ms ได้ `Done. (no text output)`
+ทั้งที่ยังไม่ได้ถามอะไรเลย — เจอตอนรัน `scripts/scenarios/codex-turns.ts` ไม่ใช่จาก test
+
+การกรองด้วย *"เป็น turn ของเราไหม"* อย่างเดียว**ไม่พอ** เพราะตอนใบเก่ามาถึง
+เทิร์นใหม่ยังไม่ได้รับ `turn/started` จึงยังไม่รู้ id ของตัวเอง
+
+adapter จึงจำ turn ที่ interrupt ไปแล้วไว้ (`#abandonedTurns`) เพื่อทิ้งใบที่ตามมา
+มี regression test ล็อกไว้ทั้งเส้นทาง timeout และ `/abort`
+
+> เป็นเหตุผลว่าทำไมต้องรัน scenario จริงถึงแม้ test จะเขียวหมด — test แต่ละตัว
+> ใช้ adapter คนละตัวจึงไม่มี state ค้างข้ามเทิร์น ส่วนของจริงใช้ตัวเดียวยาว ๆ
+
 ## ยังไม่ได้ทำ
 
 - ยังไม่ได้ยิง `codex app-server` ตัวจริง — เครื่องที่พัฒนาไม่มี codex CLI

--- a/packages/adapter-codex/src/adapter.test.ts
+++ b/packages/adapter-codex/src/adapter.test.ts
@@ -21,6 +21,16 @@ function make(over: Record<string, unknown> = {}) {
   })
 }
 
+/** รอจนเงื่อนไขเป็นจริง — กัน test เปราะจากเวลา spawn process ที่ไม่แน่นอน */
+async function waitUntil(fn: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (fn()) return
+    await new Promise((r) => setTimeout(r, 10))
+  }
+  throw new Error("รอเงื่อนไขไม่สำเร็จภายในเวลาที่กำหนด")
+}
+
 const prompt = (over: Record<string, unknown> = {}) => ({
   sessionKey: "line-c1", userId: "U1", text: "สวัสดี", isGroup: false, ...over,
 }) as any
@@ -118,8 +128,7 @@ test("/abort ส่ง turn/interrupt โดยไม่ทำลาย thread",
     const before = a.sessionInfo("line-c1")!.threadId
     assert.equal(a.abort("line-c1"), false, "ไม่มี turn เดินอยู่")
     const slow = a.sendPrompt(prompt({ text: "SLOW" }))
-    await new Promise((r) => setTimeout(r, 60))
-    assert.equal(a.abort("line-c1"), true)
+    await waitUntil(() => a.abort("line-c1"))
     await slow
     assert.equal(a.sessionInfo("line-c1")!.threadId, before, "thread ต้องยังอยู่")
   } finally { a.connection.close() }
@@ -158,4 +167,31 @@ test("prompt prefix ตรงกับ v1 ของ codex — ไม่ใช่
 test("1:1 ไม่มี GROUP CHAT และไม่มี [Group:]", () => {
   const p = buildPrefix({ isGroup: false, now: new Date("2026-08-23T07:30:05Z") })
   assert.equal(p, "[Time: 2026-08-23 14:30:05+07:00]\n\n")
+})
+
+test("turn/completed ของ turn เก่าไม่ปิดเทิร์นถัดไป — regression", async () => {
+  // เจอจริงตอนรัน scripts/scenarios/codex-turns.ts:
+  //   เทิร์น SLOW หมดเวลา → ส่ง turn/interrupt → app-server ตอบ turn/completed ของ turn เก่า
+  //   ใบนั้นมาถึงตอนเทิร์นถัดไปเริ่มแล้ว ทำให้เทิร์นใหม่จบใน 1 ms ได้ "Done. (no text output)"
+  const a = make({ promptTimeoutMs: 120 })
+  try {
+    const slow = await a.sendPrompt(prompt({ text: "SLOW" }))
+    assert.equal(slow.timedOut, true)
+
+    const next = await a.sendPrompt(prompt({ text: "ถามใหม่" }))
+    assert.equal(next.result, "สวัสดีครับ", "เทิร์นใหม่ต้องได้คำตอบของตัวเอง ไม่ใช่ผลค้างของเทิร์นเก่า")
+    assert.equal(next.timedOut, undefined)
+  } finally { a.connection.close() }
+})
+
+test("interrupt แล้วยิงต่อได้ทันที ไม่ต้องรอ", async () => {
+  const a = make({ promptTimeoutMs: 2000 })
+  try {
+    const slow = a.sendPrompt(prompt({ text: "SLOW" }))
+    // รอจน turn เริ่มจริง — spawn process + handshake + thread/start ใช้เวลาไม่แน่นอน
+    // หน่วงตายตัวทำให้ test เปราะ ไม่ใช่เพราะโค้ดผิด
+    await waitUntil(() => a.abort("line-c1"))
+    await slow
+    assert.equal((await a.sendPrompt(prompt())).result, "สวัสดีครับ")
+  } finally { a.connection.close() }
 })

--- a/packages/adapter-codex/src/adapter.ts
+++ b/packages/adapter-codex/src/adapter.ts
@@ -35,6 +35,13 @@ export class CodexAdapter implements RuntimePort {
   readonly #threads = new Map<string, ThreadState>()
   readonly #pendingModel = new Map<string, string>()
   readonly #activeTurn = new Map<string, { threadId: string; turnId: string }>()
+  /**
+   * turn ที่เรา interrupt ไปแล้ว — app-server จะส่ง `turn/completed` ของมันตามมาทีหลัง
+   * ซึ่งอาจมาถึงตอนเทิร์นใหม่เริ่มไปแล้ว ต้องจำไว้เพื่อทิ้งใบนั้น
+   * กรองด้วย "เป็น turn ของเราไหม" อย่างเดียวไม่พอ เพราะตอนใบเก่ามาถึง
+   * เทิร์นใหม่ยังไม่ได้รับ `turn/started` จึงยังไม่รู้ id ของตัวเอง
+   */
+  readonly #abandonedTurns = new Set<string>()
   readonly #model: string
   readonly #cwd: string
   readonly #timeout: number
@@ -100,8 +107,18 @@ export class CodexAdapter implements RuntimePort {
   abort(sessionKey: string): boolean {
     const active = this.#activeTurn.get(sessionKey)
     if (!active) return false
+    this.#abandon(active.turnId)
     this.connection.rpc.notify("turn/interrupt", active)
     return true
+  }
+
+  #abandon(turnId: string): void {
+    if (!turnId) return
+    this.#abandonedTurns.add(turnId)
+    // กันโตไม่หยุด — เก็บเท่าที่จำเป็นสำหรับใบที่ยังเดินทางอยู่
+    if (this.#abandonedTurns.size > 64) {
+      this.#abandonedTurns.delete(this.#abandonedTurns.values().next().value as string)
+    }
   }
 
   async #ensureThread(sessionKey: string): Promise<ThreadState> {
@@ -142,7 +159,8 @@ export class CodexAdapter implements RuntimePort {
     const unsubs: Array<() => void> = []
 
     unsubs.push(this.connection.rpc.on("turn/started", (p: any) => {
-      if (p?.turn?.id) {
+      // รับเฉพาะตัวแรก — turn ของคนอื่นบน connection เดียวกันต้องไม่มาทับ id ของเรา
+      if (p?.turn?.id && !turnId) {
         turnId = p.turn.id
         this.#activeTurn.set(input.sessionKey, { threadId: thread.threadId, turnId })
       }
@@ -152,7 +170,30 @@ export class CodexAdapter implements RuntimePort {
       if (typeof p?.text === "string") text += p.text
     }))
 
+    /**
+     * ⚠️ ต้องเช็คว่า event เป็นของ turn ตัวเองก่อน
+     *
+     * `turn/interrupt` ของเทิร์นก่อนหน้าทำให้ app-server ส่ง `turn/completed`
+     * ของ turn เก่าตามมาทีหลัง ซึ่งอาจมาถึงตอนที่เทิร์นใหม่เริ่มไปแล้ว
+     * ถ้าไม่กรอง เทิร์นใหม่จะถูกปิดทันทีด้วยผลของเทิร์นเก่า
+     * — เจอจริงตอนรัน scripts/scenarios/codex-turns.ts (เทิร์นหลัง SLOW จบใน 1 ms)
+     *
+     * ยังไม่รู้ turnId ของตัวเอง (turn/started ยังไม่มา) ให้รับไว้ก่อน
+     * เพราะแยกไม่ออกและการค้างแย่กว่าการรับผิด
+     */
+    const isMine = (id: unknown): boolean => {
+      if (typeof id === "string" && this.#abandonedTurns.has(id)) {
+        this.#abandonedTurns.delete(id)   // ใบค้างของ turn นั้นมาแล้ว ไม่ต้องจำต่อ
+        return false
+      }
+      return !turnId || !id || id === turnId
+    }
+
     unsubs.push(this.connection.rpc.on("turn/completed", (p: any) => {
+      if (!isMine(p?.turn?.id)) {
+        this.#log("ข้าม turn/completed ของ turn เก่า:", p?.turn?.id)
+        return
+      }
       // delta อาจไม่มาเลย — ดึงข้อความสุดท้ายจาก items แทน
       if (!text && Array.isArray(p?.turn?.items)) text = textFromItems(p.turn.items)
       if (p?.turn?.status === "error") {
@@ -162,6 +203,7 @@ export class CodexAdapter implements RuntimePort {
     }))
 
     unsubs.push(this.connection.rpc.on("turn/failed", (p: any) => {
+      if (!isMine(p?.turn?.id ?? p?.turnId)) return
       errorMessage = p?.error?.message ?? "turn ล้มเหลว"
       resolve()
     }))
@@ -169,7 +211,10 @@ export class CodexAdapter implements RuntimePort {
     let timedOut = false
     const timer = setTimeout(() => {
       timedOut = true
-      if (turnId) this.connection.rpc.notify("turn/interrupt", { threadId: thread.threadId, turnId })
+      if (turnId) {
+        this.#abandon(turnId)
+        this.connection.rpc.notify("turn/interrupt", { threadId: thread.threadId, turnId })
+      }
       resolve()
     }, this.#timeout)
 

--- a/scripts/scenarios/codex-turns.ts
+++ b/scripts/scenarios/codex-turns.ts
@@ -1,0 +1,88 @@
+/**
+ * เดินทุกเส้นทางของ adapter-codex ให้เห็นด้วยตา — ใช้ app-server ปลอม
+ *
+ *   node --experimental-strip-types scripts/scenarios/codex-turns.ts
+ *
+ * ใช้ของจริงได้ด้วยถ้ามี codex CLI:  CODEX_REAL=1 node --experimental-strip-types …
+ *
+ * fake ตอบตามคำที่อยู่ใน prompt — SLOW / ERROR / NODELTA / APPROVAL
+ * จึงบังคับให้เดินเส้นทางที่หายากได้โดยไม่ต้องรอให้ model ทำท่านั้นเอง
+ */
+import { fileURLToPath } from "node:url"
+import { CodexAdapter } from "@botforge/adapter-codex"
+import { runTurn, type TurnDeps } from "@botforge/core/router"
+import { SessionQueue } from "@botforge/core/session"
+import { ProfileCache, type LineProfileSource } from "@botforge/core/context"
+import { EventEmitter, MemorySink, BotforgeEvents, type TurnContext } from "@botforge/core/events"
+import { makePrincipal, toChannelId, resolveScope } from "@botforge/core/identity"
+
+const real = process.env.CODEX_REAL === "1"
+const fakePath = fileURLToPath(new URL("../../packages/adapter-codex/src/fixtures/fake-app-server.mjs", import.meta.url))
+
+const adapter = new CodexAdapter({
+  command: real ? (process.env.CODEX_BIN ?? "codex") : process.execPath,
+  args: real ? ["app-server"] : [fakePath],
+  workspaceDir: process.env.WORKSPACE_DIR ?? "/workspace",
+  promptTimeoutMs: real ? 300_000 : 400,
+})
+
+const src: LineProfileSource = {
+  async getProfile() { return { displayName: "สมชาย" } },
+  async getGroupMemberProfile() { return { displayName: "สมชาย" } },
+  async getGroupSummary() { return { groupName: "ทีมกฎหมาย" } },
+}
+const scope = resolveScope({ BOTFORGE_TENANT_ID: "smoke", BOTFORGE_WORKSPACE_ID: "smoke-codex" })
+const sink = new MemorySink()
+let out = ""
+const deps: TurnDeps = {
+  runtime: adapter,
+  transport: { async reply(_t, t) { out = t }, async push(_to, t) { out = t } },
+  queue: new SessionQueue(),
+  profiles: new ProfileCache(src),
+  events: new BotforgeEvents(new EventEmitter(scope, { sink })),
+}
+
+const RAW_GROUP = "Ca56f9e2b1c3d4e5f6a7b8c9d0e1f2a3"
+const RAW_USER = "U4af4980629f1b2c3d4e5f6a7b8c9d0e1"
+const key = toChannelId("line", RAW_GROUP)
+let n = 0
+const ctx = (): TurnContext => ({
+  executionId: `exec-codex-${++n}`, channelId: key, channelType: "line",
+  actor: makePrincipal("line", RAW_USER, "สมชาย"), messageId: `m-${n}`,
+})
+
+console.log(`app-server : ${real ? "ของจริง" : "ปลอม (fixtures)"}\n`)
+
+const turns: Array<[string, string]> = [
+  ["ถามปกติ", "ช่วยดู docker compose หน่อย"],
+  ["ถามต่อ — thread เดิม", "แล้ว log ดูยังไง"],
+  ["ตอบผ่าน items ไม่ผ่าน delta", "NODELTA ขอสรุปสั้น ๆ"],
+  ["runtime ตอบ error", "ERROR ทดสอบ"],
+  ["ค้างจนหมดเวลา", "SLOW ทดสอบ"],
+  ["ขออนุมัติรันคำสั่ง", "APPROVAL ลบไฟล์ให้หน่อย"],
+]
+
+for (const [label, text] of turns) {
+  out = ""
+  const before = adapter.sessionInfo(key)?.threadId
+  const t0 = performance.now()
+  const r = await runTurn(deps, {
+    sessionKey: key, userId: RAW_USER, text, replyToken: "T",
+    isGroup: true, groupId: RAW_GROUP, ctx: ctx(), runtimeName: "codex",
+  })
+  const after = adapter.sessionInfo(key)?.threadId
+  console.log(`━━━ ${label} (${Math.round(performance.now() - t0)} ms) ━━━`)
+  console.log(`  ผู้ใช้  : ${text}`)
+  console.log(`  ผล     : ${r.kind}`)
+  if (r.kind === "answered") console.log(`  bot    : ${out.slice(0, 200)}`)
+  if (r.kind === "failed") console.log(`  error  : ${r.error.code}`)
+  console.log(`  thread : ${after === before ? "ใช้ตัวเดิม ✓" : `ใหม่ ${after}`}`)
+  console.log()
+}
+
+console.log(`━━━ audit event ${sink.events.length} ใบ ━━━`)
+const byType: Record<string, number> = {}
+for (const e of sink.events) byType[e.event_type] = (byType[e.event_type] ?? 0) + 1
+for (const [k, v] of Object.entries(byType)) console.log(`  ${k.padEnd(20)} ${v}`)
+
+adapter.connection.close()


### PR DESCRIPTION
## bug จริงที่เจอตอนรัน ไม่ใช่จาก test

รัน `codex-turns.ts` แล้วเห็นว่าเทิร์นหลัง timeout **จบทันทีใน 1 ms** ได้ `Done. (no text output)` ทั้งที่ยังไม่ได้ถามอะไร

```
━━━ ค้างจนหมดเวลา (401 ms) ━━━     ผล: timed_out
━━━ ขออนุมัติรันคำสั่ง (1 ms) ━━━    ผล: answered · bot: Done. (no text output)   ← ผิด
```

**สาเหตุ** — `turn/interrupt` ไม่ได้ทำให้ turn หายไปเงียบ ๆ app-server ส่ง `turn/completed` ของ turn นั้นตามมาทีหลัง และใบนั้นมาถึงตอนเทิร์นถัดไปเริ่มไปแล้ว จึงไปปิดเทิร์นใหม่แทน

**fix รอบแรกยังมีรู** — กรองด้วย *"เป็น turn ของเราไหม"* อย่างเดียวไม่พอ เพราะตอนใบเก่ามาถึง เทิร์นใหม่ยังไม่ได้รับ `turn/started` จึงยังไม่รู้ id ตัวเอง แล้ว fallback ที่ว่า *"ยังไม่รู้ id ให้รับไว้ก่อน"* คือรูพอดี

**fix จริง** — จำ turn ที่ interrupt ไปแล้วไว้ (`#abandonedTurns`) แล้วทิ้งใบที่ตามมา · mark ทั้งเส้นทาง timeout และ `/abort` · cap 64 ไม่ให้โตไม่หยุด · `turn/started` รับเฉพาะตัวแรก

หลังแก้: เทิร์นสุดท้าย **7 ms** ได้ `สวัสดีครับ` ถูกต้อง

## ทำไม test เขียวหมดแต่ยังมี bug

test แต่ละตัวสร้าง adapter ใหม่ จึงไม่มี state ค้างข้ามเทิร์น — ส่วนของจริงใช้ adapter ตัวเดียวยาว ๆ หลายเทิร์นติดกัน

เพิ่ม regression test 2 ตัวล็อกทั้งสองเส้นทางแล้ว

## `scripts/scenarios/codex-turns.ts`

เดินทุกเส้นทางให้เห็นด้วยตา — ปกติ · thread เดิม · ตอบผ่าน `items` ไม่ผ่าน delta · runtime error · timeout · ขออนุมัติ

fake ตอบตามคำที่อยู่ใน prompt (`SLOW` `ERROR` `NODELTA` `APPROVAL`) จึงบังคับเส้นทางที่หายากได้โดยไม่ต้องรอให้ model ทำท่านั้นเอง

รันกับของจริงได้ด้วย: `CODEX_REAL=1 node --experimental-strip-types scripts/scenarios/codex-turns.ts`

## แก้ test ที่เปราะ

เดิมหน่วงตายตัว 50 ms ก่อนเรียก `abort()` ซึ่งไม่พอ — spawn process + handshake + `thread/start` ใช้เวลาไม่แน่นอน เปลี่ยนเป็น `waitUntil()` รอเงื่อนไขจริง

---

176 test (core 111 + opencode 38 + codex 27)
