### PR TITLE
feat(adapter-claude): RuntimePort บน Claude Agent SDK — shape ที่สาม

### DIFF
--- a/docs/architecture/feature-matrix.md
+++ b/docs/architecture/feature-matrix.md
@@ -21,16 +21,16 @@
 
 | Engine | ✅ | ⚠️ | ❌ | project ที่ใช้จริง |
 | --- | ---: | ---: | ---: | ---: |
-| `claude-code` | **64** | 1 | 16 | 2 |
-| `copilot-cli` | **63** | 1 | 17 | 1 |
+| `claude-code` | **65** | 1 | 15 | 2 |
+| `copilot-cli` | **64** | 1 | 16 | 1 |
 | `opencode` | 59 | 1 | 21 | **9** |
 | `codex` · `codex-appserver` · `qwen-code` · `gemini-cli` | 53 | 0 | 28 | 0 |
 | `adkcode` | 53 | 1 | 27 | 2 |
 | `gocode` | 53 | 0 | 28 | 0 |
 
-**ไม่มี engine ไหนได้ 81** — สูงสุดคือ `claude-code` ที่ 64
+**ไม่มี engine ไหนได้ 81** — สูงสุดคือ `claude-code` ที่ 65
 
-**ข้อที่ไม่มีสักengine เดียว: 8 ข้อ** → 4.5 · 11.1 · 11.2 · 11.3 · 12.1 · 12.2 (และ 11.4 มีแค่กลไก)
+**ข้อที่ไม่มีสักengine เดียว: 5 ข้อ** → 11.1 · 11.2 · 11.3 · 12.1 · 12.2 (และ 11.4 มีแค่กลไก · 4.5 แก้เป็น ⚠️ แล้ว)
 
 ---
 
@@ -100,11 +100,23 @@
 | 4.2 | `[SKIP]` detection | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 4.3 | Group name context | **❌** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 4.4 | Group memory injection | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| 4.5 | **Session-only injection** | **❌** | **❌** | **❌** | **❌** | **❌** | **❌** |
+| 4.5 | Session-only injection | ❌ | ⚠️ | ⚠️ | ❌ | ❌ | ❌ |
 | 4.6 | Group member profile | **❌** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 4.7 | `GROUP CHAT` instruction | ✅ | ✅ | ✅ | **❌** | ✅ | ✅ |
 
-**4.5 ไม่มีที่ไหนเลย** — checklist บรรยายว่า "inject memory เฉพาะ new session (ไม่ทุกข้อความ)" แต่ `claude-code` เรียก `getGroupMemory()` ที่บรรทัด 626 ซึ่งอยู่ใน per-message path คือ**อ่านไฟล์ memory ใหม่ทุกข้อความ** ข้อนี้เป็นความตั้งใจที่ไม่เคยถูก implement
+**4.5 — แก้คำตัดสินเดิม (2026-08-23)** · เดิมผมสรุปว่า **❌ ไม่มีที่ไหนเลย** ซึ่ง**ผิด**
+
+ของจริงแยกเป็นสองส่วนและผมดูแค่ส่วนเดียว:
+
+| | `claude-code` / `copilot-cli` |
+| --- | --- |
+| **อ่านไฟล์** `memory-{groupId}.md` | ทุกข้อความ (บรรทัด 626) — เปลืองจริง |
+| **inject เข้า prompt** | `if (!session && options?.groupMemory)` (บรรทัด 334) — **เฉพาะ session ใหม่ ตรงตาม checklist** |
+
+จึงเป็น ⚠️ ไม่ใช่ ❌ — กลไกที่ checklist บรรยายมีอยู่จริง แค่การอ่านไฟล์ไม่ได้ถูก gate ตามไปด้วย
+
+ที่ผมพลาดเพราะ grep หา `isNewSession|newSession` ซึ่งไม่มีวันเจอ โค้ดเขียนเป็น `!session`
+**คะแนนเปลี่ยน: `claude-code` 64 → 65 · `copilot-cli` 63 → 64**
 
 **`opencode` ไม่มี group context เลย** (4.3 + 4.6) — ไม่มี `getGroupName()` และไม่มี `getGroupMemberProfile()` ในไฟล์
 
@@ -248,7 +260,7 @@ workspace-cowork-opencode/
 
 **81 ข้อจึงบรรยาย repo อื่น** ที่ template ในrepo นี้ไม่เคยไล่ให้ทัน — อธิบายทั้งหมวด 11, 12 ที่หายไปเกลี้ยง และ 4.3/4.6/6.2 ที่ `opencode` ไม่มี
 
-> ตัวเลข "81 features" ใน architecture doc จึงเป็น**เป้าหมาย ไม่ใช่สถานะ** ที่มีจริงสูงสุดคือ 64
+> ตัวเลข "81 features" ใน architecture doc จึงเป็น**เป้าหมาย ไม่ใช่สถานะ** ที่มีจริงสูงสุดคือ 65
 
 ### 2. ไม่มี engine ไหนเป็น superset ของ engine อื่น
 

--- a/docs/architecture/runtime-matrix.md
+++ b/docs/architecture/runtime-matrix.md
@@ -63,7 +63,8 @@ codex app-server --listen "ws://0.0.0.0:$PORT" &
 | --- | --- | :-: |
 | `opencode` | adapter บน OpenCode serve | ✅ [`adapter-opencode`](../../packages/adapter-opencode/) |
 | `codex` + `codex-appserver` | **ยุบเป็นตัวเดียว** บน app-server/stdio | ✅ [`adapter-codex`](../../packages/adapter-codex/) |
-| `claude-code` · `copilot-cli` | SDK อยู่ใน process แล้ว — ห่อเป็น adapter | ⬜ |
+| `claude-code` | SDK อยู่ใน process แล้ว — ห่อเป็น adapter | ✅ [`adapter-claude`](../../packages/adapter-claude/) |
+| `copilot-cli` | ต่างจาก `claude-code` แค่ 41 diff-lines — น่าจะได้เกือบฟรี | ⬜ |
 | `gocode` · `adkcode` | server ของเราเอง — ห่อเป็น adapter | ⬜ |
 | `qwen-code` | รอ `qwen serve` ออกจาก experimental (Stage 2 ทำ WebSocket/OpenAPI) | ⬜ |
 | `gemini-cli` | ยังไม่มีทางเลือก — spawn ต่อไปจนกว่า PR merge | ⬜ |

--- a/packages/adapter-claude/README.md
+++ b/packages/adapter-claude/README.md
@@ -1,0 +1,95 @@
+# @botforge/adapter-claude
+
+`RuntimePort` บน **Claude Agent SDK** (`@anthropic-ai/claude-agent-sdk`)
+
+## ⚠️ Claude Agent SDK ≠ Claude API
+
+สอง package นี้ชื่อคล้ายกันแต่คนละเรื่อง:
+
+| | คืออะไร |
+| --- | --- |
+| `@anthropic-ai/sdk` | **Claude API** — คุณเขียน agent loop เอง หรือใช้ Tool Runner กับ tool ที่คุณนิยาม ไม่มี built-in tool |
+| `@anthropic-ai/claude-agent-sdk` | **Claude Code ที่ห่อเป็น library** — มี built-in tool (Read/Write/Edit/Bash/Grep/WebSearch), agent loop, context management, hooks, subagent, session |
+
+adapter นี้ห่อตัวหลัง เพราะ `bot-service-claude-code` ของ v1 ใช้ตัวนั้น
+เอกสารของ Agent SDK อยู่ที่ [code.claude.com/docs/en/agent-sdk](https://code.claude.com/docs/en/agent-sdk)
+
+## shape ที่สามของ adapter — ไม่มี IPC เลย
+
+```
+opencode   HTTP ข้าม container     process แยก
+codex      stdio JSON-RPC          child process
+claude     เรียก query() ตรง ๆ      process เดียวกับ core   ← ตัวนี้
+```
+
+ไม่มี transport ให้พัง ไม่มี framing ให้ต่อ ไม่มี handshake · session อยู่ฝั่ง SDK และอ้างกลับด้วย `resume`
+
+**พิสูจน์ว่า `RuntimePort` ไม่ได้แอบสมมติว่า runtime อยู่นอก process** — ซึ่งเป็นคำถามที่ตอบไม่ได้จนกว่าจะมี adapter แบบนี้
+
+## SDK เป็น optional peer dependency
+
+package นี้ **ไม่บังคับให้ติดตั้ง** `@anthropic-ai/claude-agent-sdk` — `import` แบบ lazy ตอนเรียกครั้งแรก
+ทำให้ typecheck และ test รันได้โดยไม่ต้องมี SDK และไม่ต้องมี API key
+
+```ts
+new ClaudeAdapter({ query })                  // ฉีดเอง — ใช้ตอน test
+new ClaudeAdapter({ workspaceDir: "/workspace" })  // โหลด SDK จริงตอนเรียกครั้งแรก
+```
+
+## สิ่งที่ adapter นี้ปลดล็อก
+
+| | ก่อนหน้านี้ | ตอนนี้ |
+| --- | --- | --- |
+| **`usage.cost_usd` ของจริง** | opencode ฟรี = $0 · codex ยังไม่ map | `total_cost_usd` จาก SDK ไหลเข้า `event/v1` |
+| **MCP** | หมวด 11 ของ feature-matrix = 0/9 | `.mcp.json` จาก workspace ส่งเข้า SDK ได้จริง |
+| **system prompt จาก workspace** | ไม่มี adapter ไหนทำ | `CLAUDE.md` + `AGENTS.md` ต่อด้วย `\n\n---\n\n` |
+
+## port gap ที่เจอจากการเขียน adapter ตัวนี้ — `groupMemory`
+
+v1 inject `[Group Memory]` เข้า prompt **เฉพาะตอนเปิด session ใหม่**:
+
+```ts
+if (!session && options?.groupMemory) { ... }   // bot-service-claude-code/src/index.ts:334
+```
+
+`PromptInput` ยังไม่มี field นี้ · แก้โดยให้ **core ดึงมาให้** (`deps.groupMemory`) แล้ว
+**adapter เป็นคนตัดสินว่าจะ inject เมื่อไหร่** เพราะมีแต่ adapter ที่รู้ว่ามี session อยู่หรือยัง
+
+> เป็น gap ที่สามที่เจอเพราะเขียน adapter จริง — ต่อจาก `userContext` (opencode)
+> การเขียน adapter ตัวที่สองที่ shape เหมือนตัวแรกจะไม่เจออะไรแบบนี้
+
+## แก้ audit ของตัวเองไปด้วย
+
+ตอนทำ A1 ผมสรุปว่า feature 4.5 (session-only injection) **ไม่มีที่ไหนเลย** ซึ่ง**ผิด** —
+grep หา `isNewSession|newSession` ที่ไม่มีวันเจอ เพราะโค้ดเขียนว่า `!session`
+
+ของจริง: **อ่านไฟล์**ทุกข้อความ (เปลืองจริง) แต่ **inject** เฉพาะ session ใหม่ (ตรงตาม checklist)
+แก้เป็น ⚠️ แล้วใน [`feature-matrix.md`](../../docs/architecture/feature-matrix.md) §4 · คะแนน `claude-code` 64 → 65
+
+## ค่าเริ่มต้น — ยกมาจาก v1
+
+```
+model            "sonnet"      alias ของ SDK ไม่ใช่ model id เต็ม
+maxTurns         10
+maxBudgetUsd     1.00          SDK หยุดเองเมื่อประเมินว่าถึงเพดาน
+permissionMode   "bypassPermissions" + allowDangerouslySkipPermissions
+```
+
+⚠️ `bypassPermissions` แปลว่า agent อ่าน/เขียนไฟล์ได้โดยไม่ถาม เหมือน `dangerFullAccess` ของ codex
+ยกมาเหมือนเดิมเพื่อไม่เปลี่ยนพฤติกรรมเงียบ ๆ แต่ควรพิจารณาก่อนใช้กับ bot ที่คนนอกเข้าถึงได้
+
+## test
+
+```bash
+npm test --prefix packages/adapter-claude
+```
+
+22 test · ฉีด SDK ปลอมที่บันทึก option ที่ถูกส่งเข้าไป จึงตรวจได้ว่า `resume` `model`
+`systemPrompt` `mcpServers` ถูกส่งถูกต้อง โดยไม่ต้องมี SDK และไม่ยิงเน็ต
+
+## ยังไม่ได้ทำ
+
+- ยังไม่ได้ยิง SDK ตัวจริง — ไม่มี API key และไม่มี `~/.claude` ในเครื่องพัฒนา
+- streaming — v1 ปล่อย `message.part.delta` ผ่าน SSE ของตัวเอง · adapter ยังคืนแต่ข้อความสุดท้าย
+  (`includePartialMessages: true` ส่งไปแล้ว แต่ยังไม่ได้ใช้ event ที่ได้กลับมา)
+- `maxTurns` / `maxBudgetUsd` ยังไม่ได้ map เป็น `error/v1` เมื่อชนเพดาน — ตอนนี้ตกเป็น `isError` ธรรมดา

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@botforge/adapter-claude",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "description": "RuntimePort บน Claude Agent SDK — in-process ไม่มี IPC",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": { "@botforge/core": "^0.0.1" },
+  "peerDependencies": { "@anthropic-ai/claude-agent-sdk": ">=0.2.50" },
+  "peerDependenciesMeta": { "@anthropic-ai/claude-agent-sdk": { "optional": true } },
+  "devDependencies": { "@types/node": "^22", "typescript": "^5.7.0" }
+}

--- a/packages/adapter-claude/src/adapter.test.ts
+++ b/packages/adapter-claude/src/adapter.test.ts
@@ -1,0 +1,214 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { ClaudeAdapter } from "./adapter.ts"
+import { buildPrefix, GROUP_CHAT_INSTRUCTION } from "./prompt.ts"
+import { loadSystemPrompt, loadMcpServers } from "./workspace.ts"
+import type { ClaudeQuery, ClaudeQueryOptions, SdkMessage } from "./sdk.ts"
+
+/** SDK ปลอม — บันทึก option ที่ถูกส่งเข้ามา แล้วคายชุด message ที่กำหนด */
+function fakeSdk(script: (prompt: string, opts?: ClaudeQueryOptions) => SdkMessage[] | Promise<SdkMessage[]>) {
+  const calls: Array<{ prompt: string; options?: ClaudeQueryOptions }> = []
+  const query: ClaudeQuery = ({ prompt, options }) => {
+    calls.push({ prompt, options })
+    return (async function* () {
+      for (const m of await script(prompt, options)) yield m
+    })()
+  }
+  return { query, calls }
+}
+
+const ok = (text: string, sessionId = "sdk-1", cost = 0.0042): SdkMessage[] => [
+  { type: "system", session_id: sessionId },
+  { type: "result", subtype: "success", session_id: sessionId, result: text, total_cost_usd: cost,
+    usage: { input_tokens: 1200, output_tokens: 340 } },
+]
+
+const prompt = (over: Record<string, unknown> = {}) => ({
+  sessionKey: "line-c1", userId: "U1", text: "สวัสดี", isGroup: false, ...over,
+}) as any
+
+function workspace(files: Record<string, string>) {
+  const dir = mkdtempSync(join(tmpdir(), "botforge-ws-"))
+  for (const [name, body] of Object.entries(files)) writeFileSync(join(dir, name), body)
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+test("เรียก query ตรง ๆ ไม่มี IPC — shape ที่สามของ adapter", async () => {
+  const { query, calls } = fakeSdk(() => ok("สวัสดีครับ"))
+  const a = new ClaudeAdapter({ query, workspaceDir: "/nope" })
+  const out = await a.sendPrompt(prompt())
+  assert.equal(out.result, "สวัสดีครับ")
+  assert.equal(calls.length, 1)
+  assert.ok(calls[0]!.prompt.endsWith("สวัสดี"))
+})
+
+test("cost และ token ไหลเข้า usage — ตัวแรกที่มีเลขจริงจาก runtime", async () => {
+  const { query } = fakeSdk(() => ok("ตอบ"))
+  const out = await new ClaudeAdapter({ query, workspaceDir: "/nope" }).sendPrompt(prompt())
+  assert.deepEqual(out.usage, { cost_usd: 0.0042, input_tokens: 1200, output_tokens: 340 })
+})
+
+test("ไม่มี cost → ไม่มี usage field", async () => {
+  const { query } = fakeSdk(() => [{ type: "result", subtype: "success", session_id: "s", result: "x", total_cost_usd: 0 }])
+  const out = await new ClaudeAdapter({ query, workspaceDir: "/nope" }).sendPrompt(prompt())
+  assert.equal("usage" in out, false)
+})
+
+test("session ถูกใช้ซ้ำผ่าน resume", async () => {
+  const { query, calls } = fakeSdk(() => ok("ตอบ", "sdk-abc"))
+  const a = new ClaudeAdapter({ query, workspaceDir: "/nope" })
+  await a.sendPrompt(prompt())
+  assert.equal(calls[0]!.options?.resume, undefined, "ครั้งแรกไม่มี resume")
+  await a.sendPrompt(prompt())
+  assert.equal(calls[1]!.options?.resume, "sdk-abc", "ครั้งที่สองต้อง resume")
+  assert.deepEqual(a.sessionInfo("line-c1"), { sessionId: "sdk-abc", model: "sonnet" })
+})
+
+test("resume พัง → ลองใหม่แบบไม่ resume หนึ่งครั้ง (ยกมาจาก v1)", async () => {
+  let n = 0
+  const { query, calls } = fakeSdk(() => {
+    n++
+    if (n === 2) throw new Error("No conversation found for session")
+    return ok("ตอบได้", `sdk-${n}`)
+  })
+  const a = new ClaudeAdapter({ query, workspaceDir: "/nope" })
+  await a.sendPrompt(prompt())
+  const out = await a.sendPrompt(prompt())
+  assert.equal(out.result, "ตอบได้")
+  assert.equal(calls.length, 3, "ครั้งที่สองพัง แล้วลองใหม่")
+  assert.equal(calls[2]!.options?.resume, undefined, "ครั้งที่ลองใหม่ต้องไม่ resume")
+})
+
+test("error ที่ไม่ใช่ session หมดอายุ → ไม่ retry และ core แปลงเป็นไทยได้", async () => {
+  let n = 0
+  const { query, calls } = fakeSdk(() => { n++; throw new Error("Server 429: rate limit exceeded") })
+  const out = await new ClaudeAdapter({ query, workspaceDir: "/nope" }).sendPrompt(prompt())
+  assert.equal(out.isError, true)
+  assert.equal(calls.length, 1, "ต้องไม่ retry")
+  const { toUserMessage } = await import("@botforge/core/errors")
+  assert.equal(toUserMessage(out.result), "เกิน rate limit ครับ รอสักครู่แล้วลองใหม่")
+})
+
+test("result subtype ที่ไม่ใช่ success → isError", async () => {
+  const { query } = fakeSdk(() => [
+    { type: "result", subtype: "error_max_turns", session_id: "s", result: "ถึงขีดจำกัด turn", is_error: true },
+  ])
+  const out = await new ClaudeAdapter({ query, workspaceDir: "/nope" }).sendPrompt(prompt())
+  assert.equal(out.isError, true)
+  assert.equal(out.result, "ถึงขีดจำกัด turn")
+})
+
+test("timeout → timedOut", async () => {
+  const { query } = fakeSdk(async (_p, opts) => {
+    await new Promise((r) => setTimeout(r, 300))
+    if (opts?.abortController?.signal.aborted) { const e = new Error("aborted"); e.name = "AbortError"; throw e }
+    return ok("ไม่ควรมาถึง")
+  })
+  const out = await new ClaudeAdapter({ query, workspaceDir: "/nope", promptTimeoutMs: 60 }).sendPrompt(prompt())
+  assert.equal(out.timedOut, true)
+})
+
+test("/abort ยกเลิกผ่าน AbortController · session ยังอยู่", async () => {
+  const { query } = fakeSdk(async (_p, opts) => {
+    await new Promise((r) => setTimeout(r, 500))
+    if (opts?.abortController?.signal.aborted) { const e = new Error("aborted"); e.name = "AbortError"; throw e }
+    return ok("ไม่ควรมาถึง")
+  })
+  const a = new ClaudeAdapter({ query, workspaceDir: "/nope", promptTimeoutMs: 5000 })
+  assert.equal(a.abort("line-c1"), false, "ยังไม่มี turn เดินอยู่")
+  const p = a.sendPrompt(prompt())
+  await new Promise((r) => setTimeout(r, 30))
+  assert.equal(a.abort("line-c1"), true)
+  assert.equal((await p).timedOut, true)
+})
+
+test("/model เปลี่ยนแล้ว session ใหม่ใช้ model ใหม่", async () => {
+  const { query, calls } = fakeSdk(() => ok("ตอบ"))
+  const a = new ClaudeAdapter({ query, workspaceDir: "/nope" })
+  await a.sendPrompt(prompt())
+  assert.equal(calls[0]!.options?.model, "sonnet")
+  a.setModel("line-c1", "opus")
+  assert.equal(a.modelOf("line-c1"), "opus")
+  await a.sendPrompt(prompt())
+  assert.equal(calls[1]!.options?.model, "opus")
+  assert.equal(calls[1]!.options?.resume, undefined, "เปลี่ยน model ต้องเริ่ม session ใหม่")
+})
+
+// ── workspace ──
+
+test("system prompt = CLAUDE.md + AGENTS.md ต่อด้วยเส้นคั่น", () => {
+  const ws = workspace({ "CLAUDE.md": "หนึ่ง", "AGENTS.md": "สอง" })
+  try {
+    assert.equal(loadSystemPrompt(ws.dir), "หนึ่ง\n\n---\n\nสอง")
+  } finally { ws.cleanup() }
+})
+
+test("ไม่มีไฟล์เลย → สตริงว่าง ไม่ throw", () => {
+  const ws = workspace({})
+  try { assert.equal(loadSystemPrompt(ws.dir), "") } finally { ws.cleanup() }
+})
+
+test("MCP โหลดจาก .mcp.json — feature 11.4 ที่ engine อื่นไม่มี", () => {
+  const ws = workspace({ ".mcp.json": JSON.stringify({ mcpServers: { context7: { url: "https://x" } } }) })
+  try {
+    assert.deepEqual(loadMcpServers(ws.dir), { context7: { url: "https://x" } })
+  } finally { ws.cleanup() }
+})
+
+test("mcpServers ว่าง หรือ JSON พัง → undefined ไม่ใช่ {}", () => {
+  const empty = workspace({ ".mcp.json": JSON.stringify({ mcpServers: {} }) })
+  const broken = workspace({ ".mcp.json": "{ พัง" })
+  const none = workspace({})
+  try {
+    assert.equal(loadMcpServers(empty.dir), undefined)
+    assert.equal(loadMcpServers(broken.dir), undefined)
+    assert.equal(loadMcpServers(none.dir), undefined)
+  } finally { empty.cleanup(); broken.cleanup(); none.cleanup() }
+})
+
+test("adapter ส่ง systemPrompt และ mcpServers จาก workspace เข้า SDK", async () => {
+  const ws = workspace({
+    "CLAUDE.md": "คุณคือ bot",
+    ".mcp.json": JSON.stringify({ mcpServers: { gh: { command: "npx" } } }),
+  })
+  try {
+    const { query, calls } = fakeSdk(() => ok("ตอบ"))
+    const a = new ClaudeAdapter({ query, workspaceDir: ws.dir })
+    await a.sendPrompt(prompt())
+    assert.equal(calls[0]!.options?.systemPrompt, "คุณคือ bot")
+    assert.deepEqual(calls[0]!.options?.mcpServers, { gh: { command: "npx" } })
+    assert.deepEqual(a.mcpServers(), { gh: { command: "npx" } })
+  } finally { ws.cleanup() }
+})
+
+// ── prompt ──
+
+test("group memory inject เฉพาะ session ใหม่ — feature 4.5", () => {
+  const base = { groupMemory: "จำไว้ว่า…", isGroup: true, now: new Date("2026-08-23T07:30:05Z") }
+  assert.ok(buildPrefix({ ...base, hasSession: false }).includes("[Group Memory]"))
+  assert.equal(buildPrefix({ ...base, hasSession: true }).includes("[Group Memory]"), false,
+    "session เดิมต้องไม่ inject ซ้ำ")
+})
+
+test("prefix ครบตามลำดับของ claude-code", () => {
+  const p = buildPrefix({
+    userContext: "[User: สมชาย]", groupName: "ทีมกฎหมาย", quotedMessageId: "m-1",
+    groupMemory: "บันทึก", hasSession: false, isGroup: true, now: new Date("2026-08-23T07:30:05Z"),
+  })
+  assert.ok(p.startsWith("[User: สมชาย] [Group: ทีมกฎหมาย] [Time: 2026-08-23 14:30:05+07:00]"))
+  assert.ok(p.indexOf("[Reply to message ID: m-1]") < p.indexOf("[Group Memory]"))
+  assert.ok(p.indexOf("[Group Memory]") < p.indexOf(GROUP_CHAT_INSTRUCTION))
+})
+
+test("adapter ส่ง group memory เข้า prompt เฉพาะเทิร์นแรก", async () => {
+  const { query, calls } = fakeSdk(() => ok("ตอบ", "sdk-x"))
+  const a = new ClaudeAdapter({ query, workspaceDir: "/nope" })
+  const p = prompt({ isGroup: true, groupId: "C1", groupMemory: "จำไว้ว่าลูกค้าชื่อ ก" })
+  await a.sendPrompt(p)
+  await a.sendPrompt(p)
+  assert.ok(calls[0]!.prompt.includes("[Group Memory]"))
+  assert.equal(calls[1]!.prompt.includes("[Group Memory]"), false)
+})

--- a/packages/adapter-claude/src/adapter.ts
+++ b/packages/adapter-claude/src/adapter.ts
@@ -1,0 +1,243 @@
+/**
+ * ClaudeAdapter — RuntimePort บน Claude Agent SDK
+ *
+ * **shape ที่สามของ adapter** — ต่างจากสองตัวแรกตรงที่ไม่มี IPC เลย
+ *
+ *   opencode   HTTP ข้าม container       process แยก
+ *   codex      stdio JSON-RPC            child process
+ *   claude     เรียก query() ตรง ๆ        **process เดียวกับ core**
+ *
+ * ไม่มี transport ให้พัง ไม่มี framing ให้ต่อ ไม่มี handshake
+ * session อยู่ที่ฝั่ง SDK และอ้างกลับด้วย `resume: sessionId`
+ */
+import type { PromptInput, RuntimeResult, RuntimePort } from "@botforge/core/router"
+import { defaultQuery, type ClaudeQuery, type SdkMessage } from "./sdk.ts"
+import { loadSystemPrompt, loadMcpServers } from "./workspace.ts"
+import { buildPrefix } from "./prompt.ts"
+
+export interface ClaudeAdapterOptions {
+  /** ฉีด query เองได้ — ใช้ตอน test หรือเมื่ออยาก wrap SDK เพิ่ม */
+  query?: ClaudeQuery
+  workspaceDir?: string
+  model?: string
+  maxTurns?: number
+  maxBudgetUsd?: number
+  promptTimeoutMs?: number
+  /** อ่าน system prompt / MCP ใหม่ทุกครั้ง — v1 cache ไว้ตอน startup */
+  reloadWorkspaceEachTurn?: boolean
+  log?: (...args: unknown[]) => void
+}
+
+/** ค่าเริ่มต้นยกมาจาก v1 — `CLAUDE_MODEL ?? "sonnet"` เป็น alias ของ SDK ไม่ใช่ model id เต็ม */
+const DEFAULTS = { model: "sonnet", maxTurns: 10, maxBudgetUsd: 1.0, timeoutMs: 300_000 }
+
+interface SessionState {
+  sdkSessionId: string
+  model: string
+}
+
+export class ClaudeAdapter implements RuntimePort {
+  readonly #sessions = new Map<string, SessionState>()
+  readonly #pendingModel = new Map<string, string>()
+  readonly #aborts = new Map<string, AbortController>()
+  readonly #opts: Required<Pick<ClaudeAdapterOptions, "workspaceDir" | "model" | "maxTurns" | "maxBudgetUsd" | "promptTimeoutMs">>
+  readonly #log: (...args: unknown[]) => void
+  readonly #injectedQuery: ClaudeQuery | undefined
+  readonly #reload: boolean
+  #systemPrompt: string | undefined
+  #mcpServers: Record<string, unknown> | undefined
+  #workspaceLoaded = false
+
+  constructor(options: ClaudeAdapterOptions = {}) {
+    this.#injectedQuery = options.query
+    this.#log = options.log ?? (() => {})
+    this.#reload = options.reloadWorkspaceEachTurn ?? false
+    this.#opts = {
+      workspaceDir: options.workspaceDir ?? "/workspace",
+      model: options.model ?? DEFAULTS.model,
+      maxTurns: options.maxTurns ?? DEFAULTS.maxTurns,
+      maxBudgetUsd: options.maxBudgetUsd ?? DEFAULTS.maxBudgetUsd,
+      promptTimeoutMs: options.promptTimeoutMs ?? DEFAULTS.timeoutMs,
+    }
+  }
+
+  // ── workspace ───────────────────────────────────────────────────────
+
+  #loadWorkspace(): void {
+    if (this.#workspaceLoaded && !this.#reload) return
+    this.#systemPrompt = loadSystemPrompt(this.#opts.workspaceDir) || undefined
+    this.#mcpServers = loadMcpServers(this.#opts.workspaceDir, this.#log)
+    this.#workspaceLoaded = true
+    if (this.#systemPrompt) this.#log(`system prompt จาก workspace ${this.#systemPrompt.length} ตัวอักษร`)
+  }
+
+  /** MCP server ที่โหลดได้ — feature 11.4 · engine อื่นไม่มีกลไกนี้เลย */
+  mcpServers(): Record<string, unknown> | undefined {
+    this.#loadWorkspace()
+    return this.#mcpServers
+  }
+
+  // ── session ─────────────────────────────────────────────────────────
+
+  modelOf(sessionKey: string): string {
+    return this.#sessions.get(sessionKey)?.model ?? this.#pendingModel.get(sessionKey) ?? this.#opts.model
+  }
+
+  setModel(sessionKey: string, model: string): void {
+    this.#sessions.delete(sessionKey)
+    this.#pendingModel.set(sessionKey, model)
+  }
+
+  resetSession(sessionKey: string): void {
+    this.#sessions.delete(sessionKey)
+  }
+
+  sessionInfo(sessionKey: string): { sessionId: string; model: string } | null {
+    const s = this.#sessions.get(sessionKey)
+    return s?.sdkSessionId ? { sessionId: s.sdkSessionId, model: s.model } : null
+  }
+
+  /** `/abort` — SDK ยกเลิกผ่าน AbortController · session ยังอยู่ resume ต่อได้ */
+  abort(sessionKey: string): boolean {
+    const c = this.#aborts.get(sessionKey)
+    if (!c || c.signal.aborted) return false
+    c.abort()
+    return true
+  }
+
+  // ── RuntimePort ─────────────────────────────────────────────────────
+
+  async sendPrompt(input: PromptInput): Promise<RuntimeResult> {
+    const query = this.#injectedQuery ?? (await defaultQuery())
+    this.#loadWorkspace()
+
+    const existing = this.#sessions.get(input.sessionKey)
+    const model = existing?.model ?? this.#pendingModel.get(input.sessionKey) ?? this.#opts.model
+
+    const prefix = buildPrefix({
+      userContext: input.userContext,
+      groupName: input.groupName,
+      quotedMessageId: input.quotedMessageId,
+      groupMemory: input.groupMemory,
+      hasSession: Boolean(existing?.sdkSessionId),
+      isGroup: input.isGroup,
+    })
+
+    const result = await this.#run(query, prefix + input.text, input.sessionKey, model, existing?.sdkSessionId)
+
+    // resume พังเพราะ session หมดอายุ → ลองใหม่แบบไม่ resume หนึ่งครั้ง (ยกมาจาก v1)
+    if (result.retryWithoutResume) {
+      this.#log("session หมดอายุ เริ่มใหม่โดยไม่ resume")
+      this.#sessions.delete(input.sessionKey)
+      const retried = await this.#run(query, prefix + input.text, input.sessionKey, model, undefined)
+      return this.#finish(input.sessionKey, model, retried)
+    }
+    return this.#finish(input.sessionKey, model, result)
+  }
+
+  #finish(sessionKey: string, model: string, r: RunOutcome): RuntimeResult {
+    if (r.sdkSessionId) {
+      this.#sessions.set(sessionKey, { sdkSessionId: r.sdkSessionId, model })
+      this.#pendingModel.delete(sessionKey)
+    }
+    if (r.timedOut) {
+      return r.text
+        ? { result: r.text, truncated: true, model }
+        : { result: "", timedOut: true, model }
+    }
+    const usage = r.costUsd > 0 || r.inputTokens || r.outputTokens
+      ? {
+          ...(r.costUsd > 0 ? { cost_usd: r.costUsd } : {}),
+          ...(r.inputTokens ? { input_tokens: r.inputTokens } : {}),
+          ...(r.outputTokens ? { output_tokens: r.outputTokens } : {}),
+        }
+      : undefined
+    return {
+      result: r.text || "Done. (no text output)",
+      ...(r.isError ? { isError: true } : {}),
+      ...(usage ? { usage } : {}),
+      model,
+    }
+  }
+
+  async #run(
+    query: ClaudeQuery,
+    prompt: string,
+    sessionKey: string,
+    model: string,
+    resume: string | undefined,
+  ): Promise<RunOutcome> {
+    const abortController = new AbortController()
+    this.#aborts.set(sessionKey, abortController)
+    const timer = setTimeout(() => abortController.abort(), this.#opts.promptTimeoutMs)
+    const out: RunOutcome = { text: "", costUsd: 0, isError: false, sdkSessionId: resume ?? "" }
+
+    try {
+      const stream = query({
+        prompt,
+        options: {
+          cwd: this.#opts.workspaceDir,
+          model,
+          maxTurns: this.#opts.maxTurns,
+          maxBudgetUsd: this.#opts.maxBudgetUsd,
+          systemPrompt: this.#systemPrompt,
+          resume,
+          mcpServers: this.#mcpServers,
+          permissionMode: "bypassPermissions",
+          allowDangerouslySkipPermissions: true,
+          includePartialMessages: true,
+          abortController,
+        },
+      })
+      for await (const msg of stream) collect(msg, out)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      const name = err instanceof Error ? err.name : ""
+      if (resume && (message.includes("not found") || message.includes("No conversation"))) {
+        return { ...out, retryWithoutResume: true }
+      }
+      if (name === "AbortError" || abortController.signal.aborted) {
+        out.timedOut = true
+      } else {
+        out.text = out.text || message
+        out.isError = true
+      }
+    } finally {
+      clearTimeout(timer)
+      this.#aborts.delete(sessionKey)
+    }
+    if (abortController.signal.aborted) out.timedOut = true
+    return out
+  }
+}
+
+interface RunOutcome {
+  text: string
+  costUsd: number
+  isError: boolean
+  sdkSessionId: string
+  inputTokens?: number
+  outputTokens?: number
+  timedOut?: boolean
+  retryWithoutResume?: boolean
+}
+
+/** อ่าน message ของ SDK — รองรับทั้ง `type: "result"` และ control result ที่ doc ใหม่ระบุ */
+function collect(msg: SdkMessage, out: RunOutcome): void {
+  if (msg.session_id) out.sdkSessionId = msg.session_id
+  const isResult = msg.type === "result" || (msg as any).control_type === "result"
+  if (!isResult) return
+
+  out.costUsd = msg.total_cost_usd ?? out.costUsd
+  out.inputTokens = msg.usage?.input_tokens ?? out.inputTokens
+  out.outputTokens = msg.usage?.output_tokens ?? out.outputTokens
+
+  const text = typeof msg.result === "string" ? msg.result : undefined
+  if (msg.subtype === "success") {
+    out.text = text ?? ""
+    out.isError = msg.is_error ?? false
+  } else {
+    out.text = text ?? (typeof msg.error === "string" ? msg.error : "Error during execution")
+    out.isError = true
+  }
+}

--- a/packages/adapter-claude/src/e2e.test.ts
+++ b/packages/adapter-claude/src/e2e.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { ClaudeAdapter } from "./adapter.ts"
+import type { ClaudeQuery, ClaudeQueryOptions, SdkMessage } from "./sdk.ts"
+import { runTurn, type TurnDeps } from "@botforge/core/router"
+import { SessionQueue } from "@botforge/core/session"
+import { ProfileCache, type LineProfileSource } from "@botforge/core/context"
+import { EventEmitter, MemorySink, BotforgeEvents, type TurnContext } from "@botforge/core/events"
+import { makePrincipal, toChannelId, resolveScope } from "@botforge/core/identity"
+
+function fakeSdk(script: (p: string, o?: ClaudeQueryOptions) => SdkMessage[]) {
+  const calls: string[] = []
+  const query: ClaudeQuery = ({ prompt, options }) => {
+    calls.push(prompt)
+    return (async function* () { for (const m of script(prompt, options)) yield m })()
+  }
+  return { query, calls }
+}
+const ok = (text: string, cost = 0.0181): SdkMessage[] => [
+  { type: "system", session_id: "sdk-e2e" },
+  { type: "result", subtype: "success", session_id: "sdk-e2e", result: text, total_cost_usd: cost },
+]
+
+const source: LineProfileSource = {
+  async getProfile() { return { displayName: "สมชาย" } },
+  async getGroupMemberProfile() { return { displayName: "สมชาย" } },
+  async getGroupSummary() { return { groupName: "ทีมกฎหมาย" } },
+}
+const RAW_GROUP = "Ca56f9e2b1c3d4e5f6a7b8c9d0e1f2a3"
+const RAW_USER = "U4af4980629f1b2c3d4e5f6a7b8c9d0e1"
+
+function harness(adapter: ClaudeAdapter, over: Partial<TurnDeps> = {}) {
+  const sent: string[] = []
+  const sink = new MemorySink()
+  const scope = resolveScope({ BOTFORGE_TENANT_ID: "legal", BOTFORGE_WORKSPACE_ID: "legal-claudecode" })
+  const deps: TurnDeps = {
+    runtime: adapter,
+    transport: { async reply(_t, x) { sent.push(x) }, async push(_to, x) { sent.push(x) } },
+    queue: new SessionQueue(),
+    profiles: new ProfileCache(source),
+    events: new BotforgeEvents(new EventEmitter(scope, { sink })),
+    ...over,
+  }
+  return { deps, sent, sink }
+}
+
+test("e2e — core ตัวเดียวกับ opencode/codex ใช้กับ Claude Agent SDK ได้", async () => {
+  const { query, calls } = fakeSdk(() => ok("นี่คือคำตอบครับ"))
+  const adapter = new ClaudeAdapter({ query, workspaceDir: "/nope" })
+  const { deps, sent, sink } = harness(adapter)
+  const channelId = toChannelId("line", RAW_GROUP)
+  const ctx: TurnContext = {
+    executionId: "exec-claude-1", channelId, channelType: "line",
+    actor: makePrincipal("line", RAW_USER, "สมชาย"),
+  }
+  const out = await runTurn(deps, {
+    sessionKey: channelId, userId: RAW_USER, text: "ช่วยดูโค้ดหน่อย",
+    replyToken: "T", isGroup: true, groupId: RAW_GROUP, ctx, runtimeName: "claude-code",
+  })
+  assert.equal(out.kind, "answered")
+  assert.deepEqual(sent, ["นี่คือคำตอบครับ"])
+  assert.ok(calls[0]!.includes("[User: สมชาย]"))
+  assert.ok(calls[0]!.includes("[Group: ทีมกฎหมาย]"))
+
+  // cost จริงตัวแรกที่ไหลเข้า event/v1 usage
+  const done = sink.events.at(-1)!
+  assert.equal(done.usage!.cost_usd, 0.0181)
+  assert.deepEqual(sink.events.map((e) => e.event_type),
+    ["STATE_TRANSITION", "EXECUTION_STARTED", "STATE_TRANSITION"])
+})
+
+test("e2e — deps.groupMemory ของ core ไหลถึง prompt และ inject แค่เทิร์นแรก", async () => {
+  const { query, calls } = fakeSdk(() => ok("ตอบ"))
+  const adapter = new ClaudeAdapter({ query, workspaceDir: "/nope" })
+  let reads = 0
+  const { deps } = harness(adapter, {
+    groupMemory: async () => { reads++; return "ลูกค้าชื่อ ก · เคยคุยเรื่องสัญญาเช่า" },
+  })
+  const channelId = toChannelId("line", RAW_GROUP)
+  const turn = {
+    sessionKey: channelId, userId: RAW_USER, text: "ถามต่อ",
+    replyToken: "T", isGroup: true, groupId: RAW_GROUP,
+  }
+  await runTurn(deps, turn)
+  await runTurn(deps, turn)
+
+  assert.ok(calls[0]!.includes("[Group Memory]"), "เทิร์นแรกต้อง inject")
+  assert.equal(calls[1]!.includes("[Group Memory]"), false, "เทิร์นสองต้องไม่ inject ซ้ำ")
+  // v1 อ่านไฟล์ทุกข้อความแม้จะ inject เฉพาะ session ใหม่ — ยกมาตามจริง
+  assert.equal(reads, 2, "core อ่านทุกเทิร์นเหมือน v1 · adapter เป็นคนตัดสินว่าจะใช้ไหม")
+})
+
+test("e2e — ไม่ใส่ deps.groupMemory ก็ไม่ดึงและไม่พัง", async () => {
+  const { query, calls } = fakeSdk(() => ok("ตอบ"))
+  const { deps } = harness(new ClaudeAdapter({ query, workspaceDir: "/nope" }))
+  const out = await runTurn(deps, {
+    sessionKey: "line-c9", userId: RAW_USER, text: "สวัสดี",
+    replyToken: "T", isGroup: true, groupId: "C9",
+  })
+  assert.equal(out.kind, "answered")
+  assert.equal(calls[0]!.includes("[Group Memory]"), false)
+})
+
+test("e2e — [SKIP] ในกลุ่มยังทำงานเหมือน adapter อื่น", async () => {
+  const { query } = fakeSdk(() => ok("[SKIP]"))
+  const { deps, sent } = harness(new ClaudeAdapter({ query, workspaceDir: "/nope" }))
+  const out = await runTurn(deps, {
+    sessionKey: "line-c2", userId: RAW_USER, text: "คุยกันเอง",
+    replyToken: "T", isGroup: true, groupId: "C2",
+  })
+  assert.equal(out.kind, "skipped")
+  assert.deepEqual(sent, [])
+})

--- a/packages/adapter-claude/src/index.ts
+++ b/packages/adapter-claude/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./sdk.ts"
+export * from "./workspace.ts"
+export * from "./prompt.ts"
+export * from "./adapter.ts"

--- a/packages/adapter-claude/src/prompt.ts
+++ b/packages/adapter-claude/src/prompt.ts
@@ -1,0 +1,41 @@
+/**
+ * ประกอบ prompt prefix แบบ claude-code
+ *
+ * ยกมาจาก `sendPrompt()` ของ `bot-service-claude-code` ที่ v1-final ทุกตัวอักษร
+ *
+ * เหมือน codex ทุกอย่าง **ยกเว้นบล็อก `[Group Memory]`** ซึ่งเป็นของ
+ * `claude-code` กับ `copilot-cli` เท่านั้น (feature 4.4)
+ *
+ * ⚠️ `[Group Memory]` inject **เฉพาะตอนเปิด session ใหม่** ไม่ใช่ทุกข้อความ
+ *    v1 เขียนเป็น `if (!session && options?.groupMemory)` — คือ feature 4.5
+ *    ที่ audit รอบแรกของเราสรุปผิดว่าไม่มีใครทำ (ดู feature-matrix.md §4)
+ */
+import { getTimeContext } from "@botforge/core/context"
+
+export const GROUP_CHAT_INSTRUCTION =
+  "[GROUP CHAT: You are in a group chat. If this message is clearly NOT directed at you (just people chatting with each other, unrelated conversations), respond with exactly [SKIP] and nothing else. If the message mentions you, asks a question, or could be directed at you, respond normally.]"
+
+export interface PrefixInput {
+  userContext?: string
+  groupName?: string
+  quotedMessageId?: string
+  groupMemory?: string
+  /** มี session อยู่แล้วหรือยัง — ตัวตัดสินว่าจะ inject group memory ไหม */
+  hasSession: boolean
+  isGroup: boolean
+  now?: Date
+}
+
+export function buildPrefix(input: PrefixInput): string {
+  let out = ""
+  if (input.userContext) out += `${input.userContext} `
+  if (input.groupName) out += `[Group: ${input.groupName}] `
+  out += `${getTimeContext(input.now)}\n\n`
+  if (input.quotedMessageId) out += `[Reply to message ID: ${input.quotedMessageId}]\n\n`
+  // เฉพาะ session ใหม่ — session เดิม model จำบริบทได้เองอยู่แล้ว
+  if (!input.hasSession && input.groupMemory) {
+    out += `[Group Memory]\n${input.groupMemory}\n[/Group Memory]\n\n`
+  }
+  if (input.isGroup) out += `${GROUP_CHAT_INSTRUCTION}\n\n`
+  return out
+}

--- a/packages/adapter-claude/src/sdk.ts
+++ b/packages/adapter-claude/src/sdk.ts
@@ -1,0 +1,75 @@
+/**
+ * port ของ Claude Agent SDK
+ *
+ * ⚠️ **Claude Agent SDK ไม่ใช่ Claude API** — เป็นคนละ package คนละ surface
+ *   `@anthropic-ai/sdk`                  Claude API — คุณเขียน loop เอง
+ *   `@anthropic-ai/claude-agent-sdk`     Claude Code ที่ห่อเป็น library
+ *                                        มี built-in tool (Read/Write/Bash/Grep)
+ *                                        loop, context management, hooks, subagent, session
+ * adapter นี้ห่อตัวหลัง เพราะ `bot-service-claude-code` ของ v1 ใช้ตัวนั้น
+ *
+ * แยกเป็น port เพราะ:
+ *   1. SDK เป็น optional peer dependency — ไม่บังคับให้คนที่ไม่ใช้ต้องลง
+ *   2. test ฉีด fake ได้ ไม่ต้องมี API key และไม่ยิงเน็ตจริง
+ *   3. เป็นรูปแบบเดียวกับ LineTransport / RpcTransport ของ adapter อื่น
+ */
+
+/** option ที่ส่งเข้า `query()` — ชื่อตรงกับ SDK */
+export interface ClaudeQueryOptions {
+  cwd?: string
+  model?: string
+  maxTurns?: number
+  maxBudgetUsd?: number
+  systemPrompt?: string
+  resume?: string
+  mcpServers?: Record<string, unknown>
+  permissionMode?: string
+  allowDangerouslySkipPermissions?: boolean
+  includePartialMessages?: boolean
+  abortController?: AbortController
+}
+
+/** message ที่ SDK ส่งกลับมา — อ่านเฉพาะ field ที่ adapter ใช้ */
+export interface SdkMessage {
+  type: string
+  session_id?: string
+  subtype?: string
+  result?: unknown
+  error?: unknown
+  is_error?: boolean
+  total_cost_usd?: number
+  usage?: { input_tokens?: number; output_tokens?: number }
+  message?: { content?: Array<Record<string, any>> }
+  event?: Record<string, any>
+  uuid?: string
+}
+
+export type ClaudeQuery = (args: {
+  prompt: string
+  options?: ClaudeQueryOptions
+}) => AsyncIterable<SdkMessage>
+
+let cached: ClaudeQuery | undefined
+
+/**
+ * โหลด `query` จาก SDK จริงแบบ lazy
+ *
+ * import ตอนเรียกครั้งแรกไม่ใช่ตอน import module เพื่อให้ package นี้
+ * ใช้กับ test และ typecheck ได้โดยไม่ต้องติดตั้ง SDK
+ */
+export async function defaultQuery(): Promise<ClaudeQuery> {
+  if (cached) return cached
+  try {
+    // import แบบ dynamic ผ่านตัวแปร เพื่อไม่ให้ typecheck ต้องการ SDK ที่เป็น optional peer
+    const specifier = "@anthropic-ai/claude-agent-sdk"
+    const mod = (await import(specifier)) as { query: ClaudeQuery }
+    cached = mod.query
+    return cached
+  } catch (err) {
+    throw new Error(
+      "ไม่พบ @anthropic-ai/claude-agent-sdk — ติดตั้งด้วย " +
+        "`npm i @anthropic-ai/claude-agent-sdk` หรือฉีด query เองผ่าน options.query\n" +
+        `สาเหตุเดิม: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}

--- a/packages/adapter-claude/src/workspace.ts
+++ b/packages/adapter-claude/src/workspace.ts
@@ -1,0 +1,48 @@
+/**
+ * อ่าน config จาก workspace — system prompt และ MCP server
+ *
+ * ยกมาจาก `loadSystemPrompt()` / `loadMcpServers()` ของ v1-final
+ * v1 อ่านครั้งเดียวตอน module load แล้ว cache ไว้ตลอดอายุ process
+ * ที่นี่ทำเป็นฟังก์ชันเรียกได้ เพื่อให้ test ชี้ไป dir อื่นได้และ reload ได้
+ */
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+/** ไฟล์ที่ประกอบเป็น system prompt เรียงตามลำดับที่ v1 อ่าน */
+export const SYSTEM_PROMPT_FILES = ["CLAUDE.md", "AGENTS.md"] as const
+
+/** ต่อด้วย `\n\n---\n\n` เหมือน v1 · ไม่มีไฟล์ไหนเลยคืนสตริงว่าง */
+export function loadSystemPrompt(workspaceDir: string): string {
+  const parts: string[] = []
+  for (const file of SYSTEM_PROMPT_FILES) {
+    try {
+      parts.push(readFileSync(join(workspaceDir, file), "utf-8"))
+    } catch {
+      // ไม่มีไฟล์ = ข้าม ไม่ใช่ error — v1 ก็เงียบ
+    }
+  }
+  return parts.join("\n\n---\n\n")
+}
+
+/**
+ * `.mcp.json` จาก workspace — รูปแบบเดียวกับ Claude Code และ Cursor
+ *
+ * คืน `undefined` เมื่อไม่มีไฟล์ หรือมีแต่ `mcpServers` ว่าง
+ * (SDK ตีความ `{}` ต่างจาก `undefined`)
+ */
+export function loadMcpServers(
+  workspaceDir: string,
+  log: (...args: unknown[]) => void = () => {},
+): Record<string, unknown> | undefined {
+  try {
+    const raw = readFileSync(join(workspaceDir, ".mcp.json"), "utf-8")
+    const config = JSON.parse(raw)
+    if (config?.mcpServers && Object.keys(config.mcpServers).length > 0) {
+      log(`โหลด MCP server: ${Object.keys(config.mcpServers).join(", ")}`)
+      return config.mcpServers
+    }
+  } catch {
+    // ไม่มีไฟล์ หรือ JSON พัง = ไม่มี MCP · v1 เงียบเหมือนกัน
+  }
+  return undefined
+}

--- a/packages/adapter-claude/tsconfig.json
+++ b/packages/adapter-claude/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2024"
+    ],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/adapter-codex/src/adapter.test.ts
+++ b/packages/adapter-codex/src/adapter.test.ts
@@ -5,6 +5,11 @@ import { CodexAdapter } from "./adapter.ts"
 import { buildPrefix, GROUP_CHAT_INSTRUCTION } from "./prompt.ts"
 
 /**
+ * ⚠️ งบเวลาใน test ตั้งไว้ที่ 600 ms ไม่ใช่ค่าที่แคบกว่านั้นโดยตั้งใจ
+ *    ทุก test spawn node process จริง — ตอนรันหลาย workspace พร้อมกัน (`npm run check`)
+ *    เวลา spawn แกว่งพอที่งบ 120–200 ms จะเกิด flake ได้
+ *    เคยเห็นแดงหนึ่งครั้งตอนรันพร้อมกัน แล้วทำซ้ำ 7 รอบไม่เกิดอีก
+ *
  * ทุก test ในไฟล์นี้คุยกับ **child process จริง** ผ่าน stdio
  * `fixtures/fake-app-server.mjs` พูด JSON-RPC เหมือนของจริง และจงใจเขียน stdout
  * เป็นก้อนละ 7 ตัวอักษร เพื่อพิสูจน์ว่า framing ต่อเศษบรรทัดถูก
@@ -91,7 +96,7 @@ test("turn status error → isError และ core แปลงเป็นไ�
 })
 
 test("timeout → timedOut ไม่ค้าง และ interrupt ถูกส่ง", async () => {
-  const a = make({ promptTimeoutMs: 150 })
+  const a = make({ promptTimeoutMs: 600 })
   try {
     const out = await a.sendPrompt(prompt({ text: "SLOW" }))
     assert.equal(out.timedOut, true)
@@ -111,7 +116,7 @@ test("auto-approve ตอบรับคำขออนุมัติให้�
 })
 
 test("ปิด auto-approve แล้วไม่มีใครตอบ — คำขอค้างจนหมดเวลา", async () => {
-  const a = make({ autoApprove: false, promptTimeoutMs: 200 })
+  const a = make({ autoApprove: false, promptTimeoutMs: 600 })
   const seen: string[] = []
   try {
     await a.connection.ensureReady()
@@ -173,7 +178,7 @@ test("turn/completed ของ turn เก่าไม่ปิดเทิร�
   // เจอจริงตอนรัน scripts/scenarios/codex-turns.ts:
   //   เทิร์น SLOW หมดเวลา → ส่ง turn/interrupt → app-server ตอบ turn/completed ของ turn เก่า
   //   ใบนั้นมาถึงตอนเทิร์นถัดไปเริ่มแล้ว ทำให้เทิร์นใหม่จบใน 1 ms ได้ "Done. (no text output)"
-  const a = make({ promptTimeoutMs: 120 })
+  const a = make({ promptTimeoutMs: 600 })
   try {
     const slow = await a.sendPrompt(prompt({ text: "SLOW" }))
     assert.equal(slow.timedOut, true)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -60,7 +60,7 @@ npm run typecheck --prefix packages/core
 > เปลี่ยน Codex → Claude โดยไม่แก้ Channel ✅ — runtime อยู่หลัง `RuntimePort` ตัวเดียว
 > เปลี่ยน LINE → Web โดยไม่แก้ Runtime · ⬜ — `LineTransport` แยกแล้ว แต่ยังไม่มี channel ที่สอง
 
-adapter ที่มีแล้ว: [`adapter-opencode`](../adapter-opencode/) · [`adapter-codex`](../adapter-codex/) —
+adapter ที่มีแล้ว 3 shape: [`adapter-opencode`](../adapter-opencode/) (HTTP) · [`adapter-codex`](../adapter-codex/) (stdio JSON-RPC) · [`adapter-claude`](../adapter-claude/) (in-process SDK) —
 พิสูจน์แล้วด้วย `e2e.test.ts` ที่วิ่งผ่าน HTTP จริง และ `scripts/smoke-opencode.ts`
 ที่ยิง OpenCode server จริงได้ด้วย model ฟรี
 

--- a/packages/core/src/router/turn.ts
+++ b/packages/core/src/router/turn.ts
@@ -38,6 +38,13 @@ export interface PromptInput {
    * ของ prompt เพราะแต่ละ runtime ประกอบ prompt ไม่เหมือนกัน
    */
   userContext?: string
+  /**
+   * memory ของกลุ่ม — `claude-code` และ `copilot-cli` ใช้ (feature 4.4)
+   *
+   * core แค่ดึงมาให้ · **adapter เป็นคนตัดสินว่าจะ inject เมื่อไหร่**
+   * เพราะ v1 inject เฉพาะตอนเปิด session ใหม่ ซึ่งมีแต่ adapter ที่รู้ว่ามี session อยู่ไหม
+   */
+  groupMemory?: string
 }
 
 export interface RuntimeResult {
@@ -61,6 +68,11 @@ export interface TurnDeps {
   events?: BotforgeEvents
   /** แสดง loading ใน 1:1 — v1 เรียกแบบ fire-and-forget ไม่รอผล */
   showLoading?: (chatId: string) => void
+  /**
+   * ดึง memory ของกลุ่ม — ไม่ใส่ก็ไม่ดึง
+   * v1 อ่านไฟล์ `memory-{groupId}.md` ทุกข้อความ แม้จะ inject เฉพาะ session ใหม่
+   */
+  groupMemory?: (groupId: string) => Promise<string | null>
   log?: (...args: unknown[]) => void
   /** ต่อท้ายว่าโดนตัดเมื่อยาวเกิน — `opencode` ไม่ทำ อีก 8 engine ทำ */
   lengthTruncationNotice?: boolean
@@ -116,6 +128,9 @@ async function runTurnBody(deps: TurnDeps, input: TurnInput): Promise<TurnOutcom
     const profile = await deps.profiles.getUser(input.userId, input.groupId)
     const groupName = input.groupId ? await deps.profiles.getGroupName(input.groupId) : null
     const userContext = formatUserContext(profile, deps.userContextFormat)
+    const groupMemory = input.isGroup && input.groupId && deps.groupMemory
+      ? await deps.groupMemory(input.groupId)
+      : null
 
     if (!input.isGroup && deps.showLoading) deps.showLoading(input.userId)
 
@@ -129,6 +144,7 @@ async function runTurnBody(deps: TurnDeps, input: TurnInput): Promise<TurnOutcom
       groupName: groupName ?? undefined,
       quotedMessageId: input.quotedMessageId,
       userContext: userContext || undefined,
+      groupMemory: groupMemory ?? undefined,
     })
 
     if (res.timedOut) {


### PR DESCRIPTION
adapter ตัวที่สาม — และเป็น **shape ใหม่** ไม่ใช่ตัวที่สามแบบเดิม ๆ

```
opencode   HTTP ข้าม container     process แยก
codex      stdio JSON-RPC          child process
claude     เรียก query() ตรง ๆ      process เดียวกับ core   ← ไม่มี IPC เลย
```

พิสูจน์ว่า `RuntimePort` **ไม่ได้แอบสมมติว่า runtime อยู่นอก process** — คำถามที่ตอบไม่ได้จนกว่าจะมี adapter แบบนี้

> ⚠️ **Claude Agent SDK ≠ Claude API** — `@anthropic-ai/claude-agent-sdk` คือ Claude Code ที่ห่อเป็น library (มี built-in tool, loop, session) ส่วน `@anthropic-ai/sdk` คือ Claude API ที่ต้องเขียน loop เอง · v1 ใช้ตัวแรก adapter นี้จึงห่อตัวแรก

## ปลดล็อกสามอย่างที่ adapter ก่อนหน้าทำไม่ได้

| | ก่อนหน้านี้ | ตอนนี้ |
| --- | --- | --- |
| `usage.cost_usd` **ของจริง** | opencode ฟรี = $0 · codex ยังไม่ map | `total_cost_usd` ไหลเข้า `event/v1` |
| **MCP** | หมวด 11 ของ feature-matrix = **0/9** | `.mcp.json` จาก workspace ส่งเข้า SDK จริง |
| system prompt จาก workspace | ไม่มี adapter ไหนทำ | `CLAUDE.md` + `AGENTS.md` |

## port gap ที่สาม — `groupMemory`

v1 inject `[Group Memory]` **เฉพาะตอนเปิด session ใหม่**:

```ts
if (!session && options?.groupMemory) { ... }   // src/index.ts:334
```

`PromptInput` ยังไม่มี field นี้ · แก้โดยให้ **core ดึงมาให้** (`deps.groupMemory`) แล้ว **adapter ตัดสินว่าจะ inject เมื่อไหร่** — มีแต่ adapter ที่รู้ว่ามี session อยู่หรือยัง

> gap ที่สามที่เจอเพราะเขียน adapter จริง ต่อจาก `userContext` (opencode) · การเขียน adapter ที่ shape เหมือนตัวเดิมจะไม่เจออะไรแบบนี้

## แก้ audit ของตัวเอง — feature 4.5

A1 สรุปว่า session-only injection **ไม่มีที่ไหนเลย** ซึ่ง**ผิด** — ผม grep หา `isNewSession|newSession` ที่ไม่มีวันเจอ เพราะโค้ดเขียนว่า `!session`

ของจริงแยกสองส่วน: **อ่านไฟล์**ทุกข้อความ (เปลืองจริง) แต่ **inject** เฉพาะ session ใหม่ (ตรงตาม checklist)

แก้เป็น ⚠️ · **คะแนน `claude-code` 64 → 65 · `copilot-cli` 63 → 64**

## แก้ flakiness ของ `adapter-codex`

เห็นแดงหนึ่งครั้งตอนรัน `npm run check` (ทุก workspace พร้อมกัน) แล้ว**ทำซ้ำ 7 รอบไม่เกิดอีก** จึงไม่ได้ระบุสาเหตุแน่ชัด

test พวกนั้น spawn node process จริง งบเวลา 120–200 ms จึงแคบเกินไปเมื่อ spawn แกว่ง — ขยายเป็น 600 ms ยังทดสอบพฤติกรรมเดิม รันซ้ำ 3 รอบหลังแก้ไม่แดงอีก

## ยังไม่ได้ทำ

ยังไม่ได้ยิง SDK ตัวจริง — ไม่มี API key และไม่มี `~/.claude` ในเครื่องพัฒนา
test ฉีด SDK ปลอมที่**บันทึก option ที่ถูกส่งเข้าไป** จึงตรวจได้ว่า `resume` `model` `systemPrompt` `mcpServers` ถูกส่งถูกต้อง

---

198 test (core 111 + opencode 38 + codex 27 + claude 22)
