### PR TITLE
feat(channel-web): channel ที่สอง — ปิด Definition of Done ครึ่งหลัง

### DIFF
--- a/packages/adapter-claude/src/sdk.ts
+++ b/packages/adapter-claude/src/sdk.ts
@@ -11,7 +11,7 @@
  * แยกเป็น port เพราะ:
  *   1. SDK เป็น optional peer dependency — ไม่บังคับให้คนที่ไม่ใช้ต้องลง
  *   2. test ฉีด fake ได้ ไม่ต้องมี API key และไม่ยิงเน็ตจริง
- *   3. เป็นรูปแบบเดียวกับ LineTransport / RpcTransport ของ adapter อื่น
+ *   3. เป็นรูปแบบเดียวกับ ChannelTransport / LineDelimitedTransport ของที่อื่น
  */
 
 /** option ที่ส่งเข้า `query()` — ชื่อตรงกับ SDK */

--- a/packages/adapter-codex/src/appserver.ts
+++ b/packages/adapter-codex/src/appserver.ts
@@ -5,7 +5,7 @@
  * app-server ตัวจริงได้ · ต่างกันที่ transport: ของเดิมใช้ WebSocket
  * ส่วนตัวนี้ใช้ stdio ซึ่งเป็นทางที่ upstream รับประกัน
  */
-import { JsonRpcClient, type LineTransport } from "./jsonrpc.ts"
+import { JsonRpcClient, type LineDelimitedTransport } from "./jsonrpc.ts"
 import { StdioTransport, type StdioOptions } from "./stdio.ts"
 
 /**
@@ -23,7 +23,7 @@ export const DEFAULT_SANDBOX_POLICY = { type: "dangerFullAccess" } as const
 
 export interface AppServerOptions extends StdioOptions {
   /** ใส่ transport เองได้ — ใช้ตอน test หรือถ้าจะลอง ws (ซึ่ง upstream ไม่ซัพพอร์ต) */
-  transport?: LineTransport
+  transport?: LineDelimitedTransport
   requestTimeoutMs?: number
   clientName?: string
   clientVersion?: string
@@ -34,7 +34,7 @@ export class AppServerConnection {
   readonly rpc: JsonRpcClient
   readonly #log: (...args: unknown[]) => void
   #ready: Promise<void> | undefined
-  #transport: LineTransport
+  #transport: LineDelimitedTransport
 
   constructor(options: AppServerOptions = {}) {
     this.#log = options.log ?? (() => {})

--- a/packages/adapter-codex/src/jsonrpc.test.ts
+++ b/packages/adapter-codex/src/jsonrpc.test.ts
@@ -1,12 +1,12 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { JsonRpcClient, RpcError, RpcClosedError, type LineTransport } from "./jsonrpc.ts"
+import { JsonRpcClient, RpcError, RpcClosedError, type LineDelimitedTransport } from "./jsonrpc.ts"
 
 function fake() {
   const sent: any[] = []
   let onLine: (l: string) => void = () => {}
   let onClose: (r?: string) => void = () => {}
-  const t: LineTransport = {
+  const t: LineDelimitedTransport = {
     send: (line) => sent.push(JSON.parse(line)),
     onLine: (h) => { onLine = h },
     onClose: (h) => { onClose = h },

--- a/packages/adapter-codex/src/jsonrpc.ts
+++ b/packages/adapter-codex/src/jsonrpc.ts
@@ -10,8 +10,13 @@
  * v1 (`bot-service-codex-appserver`) ใช้ ws · adapter นี้ใช้ stdio เป็นค่าเริ่มต้น
  */
 
-/** สิ่งที่ client ต้องการจากช่องทางสื่อสาร — หนึ่งบรรทัดคือหนึ่ง message */
-export interface LineTransport {
+/**
+ * สิ่งที่ client ต้องการจากช่องทางสื่อสาร — หนึ่งบรรทัดคือหนึ่ง message
+ *
+ * ⚠️ "Line" ที่นี่คือ **บรรทัด** ไม่ใช่ LINE แชท — คนละเรื่องกับ
+ *    `ChannelTransport` ของ core ที่เป็นทางออกของข้อความไปหาผู้ใช้
+ */
+export interface LineDelimitedTransport {
   send(line: string): void
   onLine(handler: (line: string) => void): void
   onClose(handler: (reason?: string) => void): void
@@ -45,7 +50,7 @@ export interface RpcOptions {
 }
 
 export class JsonRpcClient {
-  readonly #transport: LineTransport
+  readonly #transport: LineDelimitedTransport
   readonly #pending = new Map<number, Pending>()
   readonly #handlers = new Map<string, Set<(params: any) => void>>()
   readonly #timeout: number
@@ -53,7 +58,7 @@ export class JsonRpcClient {
   #nextId = 0
   #closed = false
 
-  constructor(transport: LineTransport, options: RpcOptions = {}) {
+  constructor(transport: LineDelimitedTransport, options: RpcOptions = {}) {
     this.#transport = transport
     this.#timeout = options.requestTimeoutMs ?? 300_000
     this.#log = options.log ?? (() => {})

--- a/packages/adapter-codex/src/stdio.ts
+++ b/packages/adapter-codex/src/stdio.ts
@@ -9,7 +9,7 @@
  * `bot-service-codex` ที่เรียก `spawn("codex", …)` ต่อหนึ่งข้อความ
  */
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
-import type { LineTransport } from "./jsonrpc.ts"
+import type { LineDelimitedTransport } from "./jsonrpc.ts"
 
 export interface StdioOptions {
   command?: string
@@ -21,7 +21,7 @@ export interface StdioOptions {
   onExit?: (code: number | null, signal: string | null) => void
 }
 
-export class StdioTransport implements LineTransport {
+export class StdioTransport implements LineDelimitedTransport {
   readonly child: ChildProcessWithoutNullStreams
   #buffer = ""
   #lineHandler: ((line: string) => void) | undefined

--- a/packages/channel-web/README.md
+++ b/packages/channel-web/README.md
@@ -1,0 +1,84 @@
+# @botforge/channel-web
+
+**Channel ที่สอง** — HTTP + SSE · มีอยู่เพื่อปิดครึ่งหลังของ Definition of Done
+
+```
+เปลี่ยน Codex → Claude โดยไม่แก้ Channel   ✅ adapter 3 ตัว 3 shape
+เปลี่ยน LINE  → Web   โดยไม่แก้ Runtime    ✅ ← ตัวนี้
+```
+
+## พิสูจน์แล้วกับ model จริง
+
+```bash
+node --experimental-strip-types scripts/web-demo.ts
+```
+
+`web-demo.ts` ใช้ **`@botforge/adapter-opencode` ตัวเดียวกับที่ LINE ใช้ โดยไม่แก้อะไรเลย** —
+ไม่มีบรรทัดไหนใน adapter ที่รู้ว่ามี Web อยู่
+
+```
+ผู้ใช้ : สวัสดีครับ ตอบสั้น ๆ ว่าคุณคือ model อะไร
+bot   : สวัสดีครับ ผมคือ ox-alpha ซึ่งพัฒนาโดยองค์กรที่ไม่เปิดเผยชื่อครับ
+ผล    : answered
+audit event รวม 3 ใบ
+```
+
+## เส้นทาง
+
+| | |
+| --- | --- |
+| `GET /` | หน้าเว็บเล็ก ๆ ไม่มี dependency ไม่มี build step |
+| `GET /events?c=<id>` | SSE — ข้อความจาก bot |
+| `POST /message` | `{ conversationId, text }` → `202` ทันที คำตอบไปทาง SSE |
+| `GET /health` | |
+
+## สิ่งที่ต่างจาก LINE และทำให้ core ต้องปรับ
+
+| | LINE | Web |
+| --- | --- | --- |
+| reply token | มี ใช้ได้ครั้งเดียว ฟรี | **ไม่มี** — `reply()` ทำงานเหมือน `push()` |
+| ลิมิตความยาว | 5000 ตัวอักษร | ไม่มี |
+| ผู้รับ | หนึ่งคน/หนึ่งกลุ่ม | **หลายแท็บในห้องเดียวกัน** |
+| ตัวตนผู้ใช้ | Profile API | ไม่มี — ใครก็ได้ที่เปิดหน้าเว็บ |
+| signature | HMAC บังคับ | token เลือกใส่ได้ |
+
+### สองจุดที่ core ต้องแก้เพราะ channel ที่สอง
+
+**1. `LineTransport` → `ChannelTransport`** — ชื่อเดิมสมัยที่มีแต่ LINE (คง alias ไว้ไม่ให้พัง)
+พร้อมเขียนกำกับว่า channel ที่ไม่มี reply token ให้ `reply()` ทำงานเหมือน `push()` ได้
+
+> ระหว่างทางเจอว่า `adapter-codex` ก็มี `LineTransport` แต่หมายถึง **line-delimited**
+> คนละเรื่องกับ LINE แชท — เปลี่ยนเป็น `LineDelimitedTransport` แล้ว
+
+**2. `SendOptions.chunkLimit`** — เดิม `sendMessage()` ผูกกับ `LINE_MAX_TEXT` ตายตัว
+Web ไม่มีลิมิต · Telegram ใช้ 4096 · ตอนมี channel เดียวมองไม่เห็นว่านี่เป็นการผูก
+
+> gap แบบเดียวกับ `userContext` / `groupMemory` ที่เจอตอนเขียน adapter —
+> ของที่แยกไว้แต่ยังไม่มีคนที่สองมาใช้ ยังพิสูจน์ไม่ได้ว่าแยกถูก
+
+## `ChannelHub` — สิ่งที่ LINE ไม่ต้องมี
+
+LINE ส่งกลับหาผู้รับคนเดียว · Web มีหลายแท็บเปิดห้องเดียวกันได้ จึงต้องมีทะเบียน subscriber
+
+- ห้องว่างแล้วลบทิ้ง — ไม่งั้น `Map` โตตามจำนวนห้องที่เคยมีคนเข้า
+- client ที่เขียนไม่ได้ถูกถอดออกเอง
+- ตอบตอนไม่มีใครฟัง → เก็บ backlog (จำกัดจำนวน) ส่งให้ client ที่ต่อทีหลัง
+
+## audit event
+
+ใช้ `channel-event/v1` ตัวเดียวกับ LINE — ต่างแค่ `channel_type: "web"` และ `channel_id: "web-<room>"`
+schema ไม่ต้องแก้เลย
+
+## test
+
+```bash
+npm test --prefix packages/channel-web
+```
+
+12 test · ยิง **HTTP + SSE จริง** ผ่าน `node:http` ไม่ใช่ mock ของ fetch
+
+## ยังไม่ได้ทำ
+
+- reconnect / `Last-Event-ID` — client ที่หลุดแล้วต่อใหม่ได้ backlog แต่ไม่มี cursor ที่แน่นอน
+- ตัวตนผู้ใช้ — ทุกคนในห้องเดียวกันคือคนเดียวกันในสายตา core (`actor` ยังไม่มี)
+- streaming ทีละ token — ตอนนี้ส่งข้อความเดียวตอนจบเทิร์น

--- a/packages/channel-web/package.json
+++ b/packages/channel-web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@botforge/channel-web",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "description": "Channel ที่สอง — HTTP + SSE · พิสูจน์ว่าเปลี่ยน channel ได้โดยไม่แตะ runtime",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": { "@botforge/core": "^0.0.1" },
+  "devDependencies": { "@types/node": "^22", "typescript": "^5.7.0" }
+}

--- a/packages/channel-web/src/hub.ts
+++ b/packages/channel-web/src/hub.ts
@@ -1,0 +1,52 @@
+/**
+ * ทะเบียน client ที่เปิด SSE ค้างไว้ แยกตามห้องสนทนา
+ *
+ * Web ไม่มี reply token แบบ LINE — ทุกข้อความออกทาง stream ที่ client เปิดค้าง
+ * ห้องหนึ่งมีได้หลาย client (หลายแท็บ) และต้องได้รับเหมือนกันทุกตัว
+ */
+export interface SseClient {
+  /** เขียนหนึ่ง event ลง stream · คืน false ถ้าเขียนไม่ได้แล้ว */
+  write(event: string, data: unknown): boolean
+  close(): void
+}
+
+export class ChannelHub {
+  readonly #rooms = new Map<string, Set<SseClient>>()
+
+  subscribe(conversationId: string, client: SseClient): () => void {
+    let set = this.#rooms.get(conversationId)
+    if (!set) this.#rooms.set(conversationId, (set = new Set()))
+    set.add(client)
+    return () => {
+      set!.delete(client)
+      // ห้องว่างแล้วเก็บกวาด — ไม่งั้น Map โตตามจำนวนห้องที่เคยมีคนเข้า
+      if (set!.size === 0) this.#rooms.delete(conversationId)
+    }
+  }
+
+  /** ส่งให้ทุก client ในห้อง · คืนจำนวนที่ส่งสำเร็จ · ตัวที่เขียนไม่ได้ถูกถอดออก */
+  broadcast(conversationId: string, event: string, data: unknown): number {
+    const set = this.#rooms.get(conversationId)
+    if (!set) return 0
+    let sent = 0
+    for (const client of [...set]) {
+      if (client.write(event, data)) sent++
+      else set.delete(client)
+    }
+    if (set.size === 0) this.#rooms.delete(conversationId)
+    return sent
+  }
+
+  clientCount(conversationId: string): number {
+    return this.#rooms.get(conversationId)?.size ?? 0
+  }
+
+  get roomCount(): number {
+    return this.#rooms.size
+  }
+
+  closeAll(): void {
+    for (const set of this.#rooms.values()) for (const c of set) c.close()
+    this.#rooms.clear()
+  }
+}

--- a/packages/channel-web/src/index.ts
+++ b/packages/channel-web/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./hub.ts"
+export * from "./transport.ts"
+export * from "./server.ts"

--- a/packages/channel-web/src/page.ts
+++ b/packages/channel-web/src/page.ts
@@ -1,0 +1,47 @@
+/** หน้าเว็บเล็ก ๆ ไว้ทดสอบ — ไม่มี dependency ไม่มี build step */
+export const PAGE = (title: string): string => `<!doctype html>
+<html lang="th"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${title}</title>
+<style>
+:root{color-scheme:light dark}
+body{font-family:system-ui,-apple-system,"Noto Sans Thai",sans-serif;max-width:44rem;margin:0 auto;padding:1.5rem;line-height:1.6}
+h1{font-size:1.1rem;margin:0 0 .25rem}
+.sub{opacity:.6;font-size:.85rem;margin-bottom:1rem}
+#log{border:1px solid color-mix(in srgb, currentColor 20%, transparent);border-radius:.5rem;padding:.75rem;height:60vh;overflow:auto}
+.m{margin:.4rem 0;padding:.5rem .7rem;border-radius:.5rem;white-space:pre-wrap;word-break:break-word}
+.user{background:color-mix(in srgb, currentColor 10%, transparent);margin-left:15%}
+.bot{background:color-mix(in srgb, currentColor 5%, transparent);margin-right:15%}
+.sys{opacity:.55;font-size:.8rem;text-align:center;background:none}
+form{display:flex;gap:.5rem;margin-top:.75rem}
+input{flex:1;padding:.6rem;border-radius:.5rem;border:1px solid color-mix(in srgb, currentColor 25%, transparent);background:transparent;color:inherit;font:inherit}
+button{padding:.6rem 1rem;border-radius:.5rem;border:0;background:currentColor;cursor:pointer}
+button span{color:Canvas}
+</style></head><body>
+<h1>${title}</h1>
+<div class="sub">channel: web · ห้อง <code id="cid"></code></div>
+<div id="log"></div>
+<form id="f"><input id="t" placeholder="พิมพ์ข้อความ…" autocomplete="off" autofocus><button><span>ส่ง</span></button></form>
+<script>
+const params = new URLSearchParams(location.search)
+const cid = params.get("c") || ("room-" + Math.random().toString(36).slice(2, 10))
+document.getElementById("cid").textContent = cid
+const log = document.getElementById("log")
+function add(cls, text){
+  const d = document.createElement("div"); d.className = "m " + cls; d.textContent = text
+  log.appendChild(d); log.scrollTop = log.scrollHeight
+}
+const es = new EventSource("/events?c=" + encodeURIComponent(cid))
+es.addEventListener("ready", () => add("sys", "เชื่อมต่อแล้ว"))
+es.addEventListener("message", e => { const d = JSON.parse(e.data); add(d.role === "user" ? "user" : "bot", d.text) })
+es.addEventListener("done", e => { const d = JSON.parse(e.data); if (d.kind !== "answered") add("sys", "ผล: " + d.kind) })
+es.onerror = () => add("sys", "การเชื่อมต่อหลุด กำลังต่อใหม่…")
+document.getElementById("f").addEventListener("submit", async ev => {
+  ev.preventDefault()
+  const input = document.getElementById("t"); const text = input.value.trim()
+  if (!text) return
+  input.value = ""
+  await fetch("/message", { method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ conversationId: cid, text }) })
+})
+</script></body></html>`

--- a/packages/channel-web/src/server.ts
+++ b/packages/channel-web/src/server.ts
@@ -1,0 +1,191 @@
+/**
+ * Web channel — HTTP + SSE
+ *
+ * เป็น channel ที่สองของ V2 · มีอยู่เพื่อพิสูจน์ครึ่งหลังของ Definition of Done:
+ *
+ *   > เปลี่ยน LINE → Web โดยไม่แก้ Runtime
+ *
+ * ไฟล์นี้ไม่ import adapter ตัวไหนเลย · ผู้เรียกส่ง `runtime` เข้ามา
+ * adapter ตัวเดียวกับที่ LINE ใช้เสียบตรงนี้ได้โดยไม่แก้อะไร
+ *
+ * เส้นทาง
+ *   GET  /                  หน้าเว็บเล็ก ๆ ไว้พิมพ์คุย
+ *   GET  /events?c=<id>     SSE — ข้อความจาก bot
+ *   POST /message           `{ conversationId, text }`
+ *   GET  /health
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
+import type { AddressInfo } from "node:net"
+import { runTurn, type RuntimePort, type TurnDeps } from "@botforge/core/router"
+import { SessionQueue } from "@botforge/core/session"
+import { ProfileCache, type LineProfileSource } from "@botforge/core/context"
+import { toChannelId } from "@botforge/core/identity"
+import type { BotforgeEvents, TurnContext } from "@botforge/core/events"
+import { ChannelHub } from "./hub.ts"
+import { WebTransport } from "./transport.ts"
+import { PAGE } from "./page.ts"
+
+export interface WebChannelOptions {
+  runtime: RuntimePort
+  port?: number
+  host?: string
+  /** ชื่อที่โชว์ให้ผู้ใช้เห็น */
+  displayName?: string
+  events?: BotforgeEvents
+  /** ต้องส่ง header `x-botforge-token` ให้ตรง — ไม่ตั้ง = เปิดให้ทุกคน */
+  token?: string
+  runtimeName?: string
+  log?: (...args: unknown[]) => void
+}
+
+export interface WebChannel {
+  server: Server
+  hub: ChannelHub
+  transport: WebTransport
+  url: string
+  close(): Promise<void>
+}
+
+/**
+ * Web ไม่มี profile API — ผู้ใช้คือใครก็ได้ที่เปิดหน้าเว็บ
+ * คืนชื่อคงที่เพื่อให้ `ProfileCache` ของ core ทำงานได้โดยไม่ต้องมี special case
+ */
+const anonymousProfiles: LineProfileSource = {
+  async getProfile() { return { displayName: "ผู้ใช้เว็บ" } },
+  async getGroupMemberProfile() { return { displayName: "ผู้ใช้เว็บ" } },
+  async getGroupSummary() { return { groupName: "web" } },
+}
+
+export function createWebChannel(options: WebChannelOptions): Promise<WebChannel> {
+  const log = options.log ?? (() => {})
+  const hub = new ChannelHub()
+  const transport = new WebTransport(hub)
+  const deps: TurnDeps = {
+    runtime: options.runtime,
+    transport,
+    queue: new SessionQueue(),
+    profiles: new ProfileCache(anonymousProfiles),
+    ...(options.events ? { events: options.events } : {}),
+    // Web ไม่มีลิมิตความยาวแบบ LINE — ไม่ต้องหั่นที่ 5000
+    log,
+  }
+  let turnSeq = 0
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost")
+
+    if (options.token && url.pathname !== "/" && req.headers["x-botforge-token"] !== options.token) {
+      return json(res, 401, { error: "token ไม่ถูกต้อง" })
+    }
+
+    if (req.method === "GET" && url.pathname === "/health") return json(res, 200, { ok: true })
+
+    if (req.method === "GET" && url.pathname === "/") {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+      return res.end(PAGE(options.displayName ?? "Botforge Web"))
+    }
+
+    if (req.method === "GET" && url.pathname === "/events") {
+      const conversationId = url.searchParams.get("c")
+      if (!conversationId) return json(res, 400, { error: "ต้องมี ?c=<conversationId>" })
+      return openStream(req, res, conversationId)
+    }
+
+    if (req.method === "POST" && url.pathname === "/message") {
+      let body = ""
+      req.on("data", (c) => { body += c })
+      req.on("end", () => {
+        void handleMessage(body, res)
+      })
+      return
+    }
+
+    json(res, 404, { error: "ไม่พบเส้นทางนี้" })
+  })
+
+  function openStream(req: IncomingMessage, res: ServerResponse, conversationId: string): void {
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    })
+    const client = {
+      write(event: string, data: unknown): boolean {
+        if (res.writableEnded) return false
+        return res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+      },
+      close(): void { if (!res.writableEnded) res.end() },
+    }
+    const unsubscribe = hub.subscribe(conversationId, client)
+    client.write("ready", { conversationId })
+    // ข้อความที่ตอบไปตอนยังไม่มีใครฟัง — ส่งตามให้
+    for (const text of transport.drain(conversationId)) {
+      client.write("message", { role: "assistant", text })
+    }
+    req.on("close", unsubscribe)
+  }
+
+  async function handleMessage(raw: string, res: ServerResponse): Promise<void> {
+    let payload: { conversationId?: string; text?: string }
+    try {
+      payload = JSON.parse(raw || "{}")
+    } catch {
+      return json(res, 400, { error: "JSON ไม่ถูกต้อง" })
+    }
+    const { conversationId, text } = payload
+    if (!conversationId || !text) return json(res, 400, { error: "ต้องมี conversationId และ text" })
+
+    let sessionKey: string
+    try {
+      sessionKey = toChannelId("web", conversationId)
+    } catch {
+      return json(res, 400, { error: "conversationId ใช้เป็น id ไม่ได้" })
+    }
+
+    // ตอบ HTTP ทันที — คำตอบของ bot ไปทาง SSE ไม่ใช่ response ของ POST นี้
+    json(res, 202, { accepted: true, sessionKey })
+    hub.broadcast(conversationId, "message", { role: "user", text })
+
+    const ctx: TurnContext | undefined = options.events
+      ? {
+          executionId: `web-exec-${++turnSeq}`,
+          channelId: sessionKey,
+          channelType: "web",
+        }
+      : undefined
+
+    try {
+      const outcome = await runTurn(deps, {
+        sessionKey: conversationId,   // transport ใช้ค่านี้เป็นห้อง SSE
+        userId: conversationId,
+        text,
+        isGroup: false,
+        ...(ctx ? { ctx } : {}),
+        ...(options.runtimeName ? { runtimeName: options.runtimeName } : {}),
+      })
+      hub.broadcast(conversationId, "done", { kind: outcome.kind })
+    } catch (err) {
+      log("เทิร์นล้ม:", err)
+      hub.broadcast(conversationId, "done", { kind: "failed" })
+    }
+  }
+
+  return new Promise((resolve) => {
+    server.listen(options.port ?? 0, options.host ?? "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo
+      resolve({
+        server, hub, transport,
+        url: `http://${options.host ?? "127.0.0.1"}:${addr.port}`,
+        close: () => new Promise<void>((done) => {
+          hub.closeAll()
+          server.close(() => done())
+        }),
+      })
+    })
+  })
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" })
+  res.end(JSON.stringify(body))
+}

--- a/packages/channel-web/src/transport.ts
+++ b/packages/channel-web/src/transport.ts
@@ -1,0 +1,46 @@
+/**
+ * ChannelTransport ของ Web — ทุกอย่างออกทาง SSE
+ *
+ * ⚠️ ไม่มีแนวคิด reply token · `reply()` จึงทำงานเหมือน `push()`
+ *    ซึ่งเป็นเหตุผลที่ `ChannelTransport` ต้องยอมให้ `reply` ทำแบบนี้ได้
+ *    (`sendMessage()` ของ core ลอง reply ก่อนแล้ว fallback เป็น push อยู่แล้ว)
+ *
+ * `to` คือ conversationId — ตรงกับ `sessionKey` ที่ core ใช้
+ */
+import type { ChannelTransport } from "@botforge/core/channel"
+import type { ChannelHub } from "./hub.ts"
+
+export class WebTransport implements ChannelTransport {
+  readonly #hub: ChannelHub
+  /** ข้อความที่ส่งตอนไม่มีใครฟัง — เก็บไว้ให้ client ที่ต่อทีหลัง */
+  readonly #backlog = new Map<string, string[]>()
+  readonly #backlogLimit: number
+
+  constructor(hub: ChannelHub, options: { backlogLimit?: number } = {}) {
+    this.#hub = hub
+    this.#backlogLimit = options.backlogLimit ?? 50
+  }
+
+  async reply(conversationId: string, text: string): Promise<void> {
+    await this.push(conversationId, text)
+  }
+
+  async push(conversationId: string, text: string): Promise<void> {
+    const sent = this.#hub.broadcast(conversationId, "message", { role: "assistant", text })
+    if (sent === 0) this.#remember(conversationId, text)
+  }
+
+  #remember(conversationId: string, text: string): void {
+    const list = this.#backlog.get(conversationId) ?? []
+    list.push(text)
+    while (list.length > this.#backlogLimit) list.shift()
+    this.#backlog.set(conversationId, list)
+  }
+
+  /** ข้อความที่ค้างอยู่ · อ่านแล้วล้าง — ใช้ตอน client เพิ่งต่อเข้ามา */
+  drain(conversationId: string): string[] {
+    const list = this.#backlog.get(conversationId) ?? []
+    this.#backlog.delete(conversationId)
+    return list
+  }
+}

--- a/packages/channel-web/src/web.test.ts
+++ b/packages/channel-web/src/web.test.ts
@@ -1,0 +1,204 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { createWebChannel } from "./server.ts"
+import { ChannelHub } from "./hub.ts"
+import { WebTransport } from "./transport.ts"
+import type { RuntimePort, PromptInput, RuntimeResult } from "@botforge/core/router"
+import { EventEmitter, MemorySink, BotforgeEvents } from "@botforge/core/events"
+import { resolveScope } from "@botforge/core/identity"
+
+/** runtime ปลอม — บันทึกสิ่งที่ core ส่งมาให้ */
+function fakeRuntime(reply: (i: PromptInput) => RuntimeResult | Promise<RuntimeResult>) {
+  const seen: PromptInput[] = []
+  const runtime: RuntimePort = { async sendPrompt(i) { seen.push(i); return reply(i) } }
+  return { runtime, seen }
+}
+
+/** อ่าน SSE จนกว่าจะเจอ event ที่รอ */
+async function collectSse(url: string, want: string, timeoutMs = 4000): Promise<any[]> {
+  const ac = new AbortController()
+  const timer = setTimeout(() => ac.abort(), timeoutMs)
+  const res = await fetch(url, { signal: ac.signal })
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  const events: any[] = []
+  let buf = ""
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      let i
+      while ((i = buf.indexOf("\n\n")) >= 0) {
+        const frame = buf.slice(0, i); buf = buf.slice(i + 2)
+        const ev = /^event: (.+)$/m.exec(frame)?.[1]
+        const data = /^data: (.+)$/m.exec(frame)?.[1]
+        if (ev && data) events.push({ event: ev, data: JSON.parse(data) })
+      }
+      if (events.some((e) => e.event === want)) break
+    }
+  } finally { clearTimeout(timer); ac.abort() }
+  return events
+}
+
+const post = (url: string, body: unknown, headers: Record<string, string> = {}) =>
+  fetch(`${url}/message`, { method: "POST", headers: { "content-type": "application/json", ...headers }, body: JSON.stringify(body) })
+
+test("ข้อความจากเว็บถึง runtime แล้วกลับมาทาง SSE", async () => {
+  const { runtime, seen } = fakeRuntime(() => ({ result: "สวัสดีจากบอท" }))
+  const ch = await createWebChannel({ runtime })
+  try {
+    const sse = collectSse(`${ch.url}/events?c=room-1`, "done")
+    await new Promise((r) => setTimeout(r, 50))
+    const res = await post(ch.url, { conversationId: "room-1", text: "สวัสดี" })
+    assert.equal(res.status, 202)
+
+    const events = await sse
+    assert.deepEqual(events.map((e) => e.event), ["ready", "message", "message", "done"])
+    assert.deepEqual(events[1]!.data, { role: "user", text: "สวัสดี" })
+    assert.deepEqual(events[2]!.data, { role: "assistant", text: "สวัสดีจากบอท" })
+    assert.deepEqual(events[3]!.data, { kind: "answered" })
+
+    // runtime ได้รับ sessionKey เป็น id ที่ผ่าน toChannelId แล้ว
+    assert.equal(seen.length, 1)
+    assert.equal(seen[0]!.text, "สวัสดี")
+    assert.equal(seen[0]!.isGroup, false)
+  } finally { await ch.close() }
+})
+
+test("หลายแท็บในห้องเดียวกันได้รับเหมือนกัน", async () => {
+  const { runtime } = fakeRuntime(() => ({ result: "ตอบ" }))
+  const ch = await createWebChannel({ runtime })
+  try {
+    const a = collectSse(`${ch.url}/events?c=room-2`, "done")
+    const b = collectSse(`${ch.url}/events?c=room-2`, "done")
+    await new Promise((r) => setTimeout(r, 80))
+    await post(ch.url, { conversationId: "room-2", text: "ถาม" })
+    const [ea, eb] = await Promise.all([a, b])
+    for (const events of [ea, eb]) {
+      assert.ok(events.some((e) => e.event === "message" && e.data.role === "assistant"))
+    }
+  } finally { await ch.close() }
+})
+
+test("ห้องต่างกันไม่ได้ยินกัน", async () => {
+  const { runtime } = fakeRuntime((i) => ({ result: `ตอบ:${i.text}` }))
+  const ch = await createWebChannel({ runtime })
+  try {
+    const a = collectSse(`${ch.url}/events?c=room-a`, "done")
+    await new Promise((r) => setTimeout(r, 50))
+    await post(ch.url, { conversationId: "room-b", text: "ของห้อง b" })
+    await post(ch.url, { conversationId: "room-a", text: "ของห้อง a" })
+    const events = await a
+    const texts = events.filter((e) => e.event === "message").map((e) => e.data.text)
+    assert.ok(texts.includes("ของห้อง a"))
+    assert.equal(texts.some((t) => String(t).includes("ห้อง b")), false)
+  } finally { await ch.close() }
+})
+
+test("ตอบตอนยังไม่มีใครฟัง → เก็บไว้ให้ client ที่ต่อทีหลัง", async () => {
+  const { runtime } = fakeRuntime(() => ({ result: "ตอบตอนไม่มีคนฟัง" }))
+  const ch = await createWebChannel({ runtime })
+  try {
+    await post(ch.url, { conversationId: "room-late", text: "ถามก่อนเปิดแท็บ" })
+    await new Promise((r) => setTimeout(r, 120))
+    const events = await collectSse(`${ch.url}/events?c=room-late`, "message")
+    assert.ok(events.some((e) => e.event === "message" && e.data.text === "ตอบตอนไม่มีคนฟัง"))
+  } finally { await ch.close() }
+})
+
+test("payload ไม่ครบ → 400 · conversationId ที่ใช้เป็น id ไม่ได้ → 400", async () => {
+  const { runtime } = fakeRuntime(() => ({ result: "x" }))
+  const ch = await createWebChannel({ runtime })
+  try {
+    assert.equal((await post(ch.url, { text: "ไม่มี id" })).status, 400)
+    assert.equal((await post(ch.url, { conversationId: "r" })).status, 400)
+    assert.equal((await post(ch.url, { conversationId: "มีไทย ไม่ได้", text: "hi" })).status, 400)
+    assert.equal((await fetch(`${ch.url}/events`)).status, 400, "ไม่มี ?c=")
+  } finally { await ch.close() }
+})
+
+test("token ปิดกั้นได้ และหน้าเว็บยังเปิดได้", async () => {
+  const { runtime } = fakeRuntime(() => ({ result: "x" }))
+  const ch = await createWebChannel({ runtime, token: "s3cret" })
+  try {
+    assert.equal((await post(ch.url, { conversationId: "r1", text: "hi" })).status, 401)
+    assert.equal((await post(ch.url, { conversationId: "r1", text: "hi" }, { "x-botforge-token": "s3cret" })).status, 202)
+    assert.equal((await fetch(ch.url)).status, 200, "หน้าเว็บต้องเปิดได้เพื่อให้ผู้ใช้ใส่ token")
+  } finally { await ch.close() }
+})
+
+test("runtime ล้ม → ผู้ใช้ได้ข้อความไทยจาก core และ done: answered", async () => {
+  const { runtime } = fakeRuntime(() => { throw new Error("Server 429: rate limit exceeded") })
+  const ch = await createWebChannel({ runtime })
+  try {
+    const sse = collectSse(`${ch.url}/events?c=room-err`, "done")
+    await new Promise((r) => setTimeout(r, 50))
+    await post(ch.url, { conversationId: "room-err", text: "ถาม" })
+    const events = await sse
+    const bot = events.find((e) => e.event === "message" && e.data.role === "assistant")
+    assert.equal(bot!.data.text, "เกิน rate limit ครับ รอสักครู่แล้วลองใหม่")
+    assert.deepEqual(events.at(-1)!.data, { kind: "failed" })
+  } finally { await ch.close() }
+})
+
+test("audit event ใช้ channel_type: web — schema เดียวกับ LINE", async () => {
+  const { runtime } = fakeRuntime(() => ({ result: "ตอบ" }))
+  const sink = new MemorySink()
+  const scope = resolveScope({ BOTFORGE_TENANT_ID: "demo", BOTFORGE_WORKSPACE_ID: "demo-web" })
+  const ch = await createWebChannel({
+    runtime, runtimeName: "fake",
+    events: new BotforgeEvents(new EventEmitter(scope, { sink })),
+  })
+  try {
+    const sse = collectSse(`${ch.url}/events?c=room-ev`, "done")
+    await new Promise((r) => setTimeout(r, 50))
+    await post(ch.url, { conversationId: "room-ev", text: "ถาม" })
+    await sse
+    assert.deepEqual(sink.events.map((e) => e.event_type),
+      ["STATE_TRANSITION", "EXECUTION_STARTED", "STATE_TRANSITION"])
+    assert.equal(sink.events[0]!.channel_type, "web")
+    assert.equal(sink.events[0]!.channel_id, "web-room-ev")
+  } finally { await ch.close() }
+})
+
+test("health และหน้าเว็บ", async () => {
+  const { runtime } = fakeRuntime(() => ({ result: "x" }))
+  const ch = await createWebChannel({ runtime, displayName: "ทดสอบ" })
+  try {
+    assert.deepEqual(await (await fetch(`${ch.url}/health`)).json(), { ok: true })
+    const html = await (await fetch(ch.url)).text()
+    assert.ok(html.includes("ทดสอบ"))
+    assert.ok(html.includes("EventSource"))
+    assert.equal((await fetch(`${ch.url}/ไม่มี`)).status, 404)
+  } finally { await ch.close() }
+})
+
+// ── hub / transport ──
+
+test("hub เก็บกวาดห้องที่ว่างแล้ว", () => {
+  const hub = new ChannelHub()
+  const client = { write: () => true, close: () => {} }
+  const off = hub.subscribe("r", client)
+  assert.equal(hub.roomCount, 1)
+  off()
+  assert.equal(hub.roomCount, 0, "ห้องว่างต้องถูกลบ ไม่งั้น Map โตตามจำนวนห้องที่เคยมีคนเข้า")
+})
+
+test("client ที่เขียนไม่ได้ถูกถอดออกเอง", () => {
+  const hub = new ChannelHub()
+  hub.subscribe("r", { write: () => false, close: () => {} })
+  hub.subscribe("r", { write: () => true, close: () => {} })
+  assert.equal(hub.broadcast("r", "message", {}), 1)
+  assert.equal(hub.clientCount("r"), 1)
+})
+
+test("backlog จำกัดจำนวน ไม่โตไม่หยุด", async () => {
+  const hub = new ChannelHub()
+  const t = new WebTransport(hub, { backlogLimit: 3 })
+  for (let i = 0; i < 10; i++) await t.push("r", `ข้อความ ${i}`)
+  const drained = t.drain("r")
+  assert.equal(drained.length, 3)
+  assert.deepEqual(drained, ["ข้อความ 7", "ข้อความ 8", "ข้อความ 9"], "เก็บอันล่าสุด")
+  assert.deepEqual(t.drain("r"), [], "drain แล้วต้องว่าง")
+})

--- a/packages/channel-web/tsconfig.json
+++ b/packages/channel-web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2024"
+    ],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -58,7 +58,7 @@ npm run typecheck --prefix packages/core
 และ Definition of Done ของ V2:
 
 > เปลี่ยน Codex → Claude โดยไม่แก้ Channel ✅ — runtime อยู่หลัง `RuntimePort` ตัวเดียว
-> เปลี่ยน LINE → Web โดยไม่แก้ Runtime · ⬜ — `LineTransport` แยกแล้ว แต่ยังไม่มี channel ที่สอง
+> เปลี่ยน LINE → Web โดยไม่แก้ Runtime ✅ — [`channel-web`](../channel-web/) ใช้ `adapter-opencode` ตัวเดิมโดยไม่แก้อะไร ยืนยันกับ model จริงแล้ว
 
 adapter ที่มีแล้ว 3 shape: [`adapter-opencode`](../adapter-opencode/) (HTTP) · [`adapter-codex`](../adapter-codex/) (stdio JSON-RPC) · [`adapter-claude`](../adapter-claude/) (in-process SDK) —
 พิสูจน์แล้วด้วย `e2e.test.ts` ที่วิ่งผ่าน HTTP จริง และ `scripts/smoke-opencode.ts`

--- a/packages/core/src/channel/send.test.ts
+++ b/packages/core/src/channel/send.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { sendMessage, type LineTransport } from "./send.ts"
+import { sendMessage, type ChannelTransport } from "./send.ts"
 import { LINE_MAX_TEXT } from "./line.ts"
 
 interface Call { kind: "reply" | "push"; target: string; text: string }
@@ -11,7 +11,7 @@ function fakeTransport(opts: {
 } = {}) {
   const calls: Call[] = []
   let pushCount = 0
-  const transport: LineTransport = {
+  const transport: ChannelTransport = {
     async reply(replyToken, text) {
       calls.push({ kind: "reply", target: replyToken, text })
       if (opts.replyFails) throw new Error("Invalid reply token")

--- a/packages/core/src/channel/send.ts
+++ b/packages/core/src/channel/send.ts
@@ -9,13 +9,29 @@
  */
 import { chunkText } from "./line.ts"
 
-/** สิ่งที่ core ต้องการจาก LINE SDK — ฝั่ง adapter เป็นคนต่อของจริง */
-export interface LineTransport {
+/**
+ * ทางออกของข้อความ — channel adapter เป็นคนต่อของจริง
+ *
+ * `reply` คือช่องทางที่ถูกกว่า/เร็วกว่าและใช้ได้ครั้งเดียว (LINE reply token)
+ * channel ที่ไม่มีแนวคิดนี้ (เช่น Web) ให้ `reply` ทำงานเหมือน `push` ได้เลย
+ * — `sendMessage()` จะ fallback ไป `push` เองอยู่แล้วถ้า reply โยน error
+ */
+export interface ChannelTransport {
   reply(replyToken: string, text: string): Promise<void>
   push(to: string, text: string): Promise<void>
 }
 
+/** @deprecated ชื่อเดิมสมัยที่มีแต่ LINE — ใช้ `ChannelTransport` แทน */
+export type LineTransport = ChannelTransport
+
 export interface SendOptions {
+  /**
+   * ลิมิตความยาวต่อ chunk — ค่าเริ่มต้นคือของ LINE (5000)
+   *
+   * channel อื่นมีลิมิตต่างกัน (Web แทบไม่มี · Telegram 4096)
+   * เพิ่มเข้ามาตอนทำ channel ที่สอง เพราะเดิม `sendMessage()` ผูกกับลิมิตของ LINE ตายตัว
+   */
+  chunkLimit?: number
   /** จำนวนครั้งที่ push ได้ต่อ chunk — v1 ใช้ 3 */
   maxAttempts?: number
   /** หน่วง backoff ต่อครั้ง — v1 ใช้ (attempt + 1) * 5000 ms */
@@ -47,7 +63,7 @@ function messageOf(err: unknown): string {
  * ผู้เรียกที่อยากรู้ว่าสำเร็จไหมให้ดูค่าที่คืน
  */
 export async function sendMessage(
-  transport: LineTransport,
+  transport: ChannelTransport,
   to: string,
   text: string,
   replyToken?: string,
@@ -59,7 +75,7 @@ export async function sendMessage(
   const log = options.log ?? (() => {})
   const error = options.error ?? (() => {})
 
-  const chunks = chunkText(text)
+  const chunks = chunkText(text, options.chunkLimit)
   let delivered = 0
   let failed = 0
 

--- a/packages/core/src/router/turn.ts
+++ b/packages/core/src/router/turn.ts
@@ -8,7 +8,7 @@
  * runtime ถูกแยกเป็น port ตัวเดียว (`RuntimePort`) จึงเปลี่ยน Codex เป็น Claude
  * ได้โดยไม่ต้องแตะ channel ตาม Definition of Done ของ V2
  */
-import type { LineTransport } from "../channel/send.ts"
+import type { ChannelTransport } from "../channel/send.ts"
 import { sendMessage } from "../channel/send.ts"
 import { formatUserContext, type ProfileCache, type UserContextFormat } from "../context/profile.ts"
 import type { SessionQueue } from "../session/queue.ts"
@@ -62,7 +62,7 @@ export interface RuntimeResult {
 
 export interface TurnDeps {
   runtime: RuntimePort
-  transport: LineTransport
+  transport: ChannelTransport
   queue: SessionQueue
   profiles: ProfileCache
   events?: BotforgeEvents

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,3 +43,16 @@ docker rm -f botforge-v2-smoke      # เลิกใช้แล้วลบ
 
 `opencode/big-pickle` กับ `opencode/nemotron-3-super` ใช้ได้เลยโดยไม่ต้องมี API key
 ส่วน provider อื่นใน `opencode.json` ต้องมี key ของแต่ละเจ้า
+
+
+## `web-demo.ts` — Definition of Done ครึ่งหลัง
+
+```bash
+node --experimental-strip-types scripts/web-demo.ts
+# แล้วเปิด http://127.0.0.1:8788
+```
+
+ใช้ **`adapter-opencode` ตัวเดียวกับที่ LINE ใช้ โดยไม่แก้อะไรเลย** ต่อ Web channel แทน
+พิสูจน์ว่า *"เปลี่ยน LINE → Web โดยไม่แก้ Runtime"* ทำได้จริง
+
+ต้องมี OpenCode server รันอยู่ (ดูข้างบน) · `PORT` เปลี่ยนได้ · `BOTFORGE_MODEL` เลือก model ได้

--- a/scripts/web-demo.ts
+++ b/scripts/web-demo.ts
@@ -1,0 +1,65 @@
+/**
+ * Definition of Done ครึ่งหลัง — เปลี่ยน LINE → Web โดยไม่แก้ Runtime
+ *
+ *   node --experimental-strip-types scripts/web-demo.ts
+ *
+ * ใช้ `@botforge/adapter-opencode` **ตัวเดียวกับที่ LINE ใช้** โดยไม่แก้อะไรเลย
+ * ต่อ Web channel แทน แล้วเปิดเบราว์เซอร์คุยได้
+ *
+ * env: OPENCODE_URL (ค่าเริ่มต้น http://127.0.0.1:4096) · PORT · BOTFORGE_MODEL
+ */
+import { OpenCodeAdapter, FREE_MODELS } from "@botforge/adapter-opencode"
+import { createWebChannel } from "@botforge/channel-web"
+import { EventEmitter, MemorySink, BotforgeEvents } from "@botforge/core/events"
+import { resolveScope } from "@botforge/core/identity"
+
+const url = process.env.OPENCODE_URL ?? "http://127.0.0.1:4096"
+const model = process.env.BOTFORGE_MODEL ?? FREE_MODELS[0]
+
+// adapter ตัวเดียวกับที่ LINE ใช้ — ไม่มีอะไรเกี่ยวกับ Web ในนี้เลย
+const runtime = new OpenCodeAdapter({
+  url,
+  password: process.env.OPENCODE_PASSWORD,
+  directory: process.env.OPENCODE_DIR ?? "/workspace",
+  promptTimeoutMs: Number(process.env.PROMPT_TIMEOUT_MS ?? 150_000),
+})
+
+process.stdout.write(`รอ OpenCode ที่ ${url} ... `)
+if (!(await runtime.client.waitUntilReady(5, 1000, () => process.stdout.write(".")))) {
+  console.error(`\n✗ ต่อไม่ได้ — สตาร์ท server ก่อน (ดู scripts/README.md)`)
+  process.exit(1)
+}
+console.log(" พร้อม")
+
+const sink = new MemorySink()
+const scope = resolveScope({
+  BOTFORGE_TENANT_ID: process.env.BOTFORGE_TENANT_ID ?? "demo",
+  BOTFORGE_WORKSPACE_ID: process.env.BOTFORGE_WORKSPACE_ID ?? "demo-web",
+})
+
+const channel = await createWebChannel({
+  runtime,
+  port: Number(process.env.PORT ?? 8788),
+  displayName: `Botforge Web · ${model}`,
+  events: new BotforgeEvents(new EventEmitter(scope, { sink })),
+  runtimeName: "opencode",
+  log: (...a) => console.log("  [core]", ...a),
+})
+
+console.log(`\n  เปิด ${channel.url} แล้วพิมพ์คุยได้เลย`)
+console.log(`  runtime : opencode (${model}) — adapter ตัวเดียวกับที่ LINE ใช้ ไม่ได้แก้อะไร`)
+console.log(`  channel : web (HTTP + SSE)\n  Ctrl-C เพื่อออก\n`)
+
+const report = setInterval(() => {
+  if (sink.events.length === 0) return
+  const last = sink.events.at(-1)!
+  console.log(`  [event] ${sink.events.length} ใบ · ล่าสุด ${last.event_type}${last.transition ? ` ${last.transition.from}→${last.transition.to}` : ""}`)
+}, 5000)
+
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    clearInterval(report)
+    console.log(`\nปิด · audit event รวม ${sink.events.length} ใบ`)
+    void channel.close().then(() => process.exit(0))
+  })
+}


### PR DESCRIPTION
## Definition of Done ปิดครบแล้ว

```
เปลี่ยน Codex → Claude โดยไม่แก้ Channel   ✅ adapter 3 ตัว 3 shape
เปลี่ยน LINE  → Web   โดยไม่แก้ Runtime    ✅ ← PR นี้
```

`scripts/web-demo.ts` ใช้ **`adapter-opencode` ตัวเดียวกับที่ LINE ใช้ โดยไม่แก้อะไรเลย** ยิง model ฟรีจริง:

```
ผู้ใช้ : สวัสดีครับ ตอบสั้น ๆ ว่าคุณคือ model อะไร
bot   : สวัสดีครับ ผมคือ ox-alpha ซึ่งพัฒนาโดยองค์กรที่ไม่เปิดเผยชื่อครับ
ผล    : answered · audit event 3 ใบ
```

## สองจุดที่ core ต้องแก้เพราะมี channel ที่สอง

**`LineTransport` → `ChannelTransport`** — ชื่อเดิมสมัยที่มีแต่ LINE (คง alias) พร้อมเขียนกำกับว่า channel ที่ไม่มี reply token ให้ `reply()` ทำเหมือน `push()` ได้

**`SendOptions.chunkLimit`** — เดิม `sendMessage()` ผูกกับ `LINE_MAX_TEXT` ตายตัว · Web ไม่มีลิมิต · Telegram 4096 · **ตอนมี channel เดียวมองไม่เห็นว่านี่เป็นการผูก**

> gap แบบเดียวกับ `userContext` / `groupMemory` ที่เจอตอนเขียน adapter — ของที่แยกไว้แต่ยังไม่มีคนที่สองมาใช้ ยังพิสูจน์ไม่ได้ว่าแยกถูก

## เจอชื่อชนที่ผมสร้างเอง

`adapter-codex` ก็มี `LineTransport` แต่หมายถึง **line-delimited** คนละเรื่องกับ LINE แชท — เปลี่ยนเป็น `LineDelimitedTransport`

## `ChannelHub` — สิ่งที่ LINE ไม่ต้องมี

LINE ส่งกลับหาผู้รับคนเดียว · Web มี**หลายแท็บเปิดห้องเดียวกัน**ได้

- ห้องว่างแล้วลบทิ้ง (ไม่งั้น `Map` โตตามจำนวนห้องที่เคยมีคนเข้า)
- client ที่เขียนไม่ได้ถูกถอดออกเอง
- ตอบตอนไม่มีใครฟัง → backlog จำกัดจำนวน ส่งให้ client ที่ต่อทีหลัง

## audit event — schema ไม่ต้องแก้เลย

`channel-event/v1` ตัวเดิม ต่างแค่ `channel_type: "web"` · `channel_id: "web-<room>"`

## ยังไม่ได้ทำ

reconnect/`Last-Event-ID` · ตัวตนผู้ใช้ (`actor` ยังไม่มี — ทุกคนในห้องคือคนเดียวกันในสายตา core) · streaming ทีละ token

---

12 test ยิง HTTP + SSE จริงผ่าน `node:http` · รวม **210 test**
