### PR TITLE
feat(adapter-adkcode): RuntimePort สำหรับ Google ADK multi-agent

### DIFF
--- a/conformance/emit_payloads.ts
+++ b/conformance/emit_payloads.ts
@@ -26,6 +26,7 @@ const RAW_ERRORS: string[] = [
   "ECONNREFUSED 127.0.0.1:4096",
   "Unexpected end of JSON input",
   "401 model has reached daily limit for this key",
+  "session line-c1 กำลังทำงานอยู่ (409 conflict)",
   "auth failed for sk-proj-AbCdEf1234567890XyZ",
   "Bearer eyJhbGciOiJIUzI1NiJ9abcdefghijklmnop rejected",
 ]

--- a/docs/architecture/runtime-matrix.md
+++ b/docs/architecture/runtime-matrix.md
@@ -66,7 +66,8 @@ codex app-server --listen "ws://0.0.0.0:$PORT" &
 | `codex` + `codex-appserver` | **ยุบเป็นตัวเดียว** บน app-server/stdio | ✅ [`adapter-codex`](../../packages/adapter-codex/) |
 | `claude-code` | SDK อยู่ใน process แล้ว — ห่อเป็น adapter | ✅ [`adapter-claude`](../../packages/adapter-claude/) |
 | `copilot-cli` | ต่างจาก `claude-code` แค่ 41 diff-lines — น่าจะได้เกือบฟรี | ⬜ |
-| `gocode` · `adkcode` | server ของเราเอง — ห่อเป็น adapter | ⬜ |
+| `adkcode` | server ของเราเอง (FastAPI + ADK) — **multi-agent ตัวเดียวใน 9** | ✅ [`adapter-adkcode`](../../packages/adapter-adkcode/) |
+| `gocode` | server ของเราเอง (Go + chi) · ไม่มี project ใช้ | ⬜ |
 | `qwen-code` | รอ `qwen serve` ออกจาก experimental (Stage 2 ทำ WebSocket/OpenAPI) | ⬜ |
 | `gemini-cli` | ยังไม่มีทางเลือก — spawn ต่อไปจนกว่า PR merge | ⬜ |
 

--- a/packages/adapter-adkcode/README.md
+++ b/packages/adapter-adkcode/README.md
@@ -1,0 +1,85 @@
+# @botforge/adapter-adkcode
+
+`RuntimePort` สำหรับ **adkcode** — Google ADK multi-agent หลัง FastAPI
+
+## engine เดียวใน 9 ที่เป็น multi-agent จริง
+
+```python
+root_agent = Agent(..., sub_agents=[coder, reviewer, tester])
+```
+
+หนึ่ง prompt แตกเป็นหลาย agent · `coder` เขียนโค้ด · `reviewer` อ่านอย่างเดียว · `tester` รันเทสต์
+
+## ทำไมยังปล่อย execution เดียว ไม่ใช่ tree
+
+`execution/v1` รองรับ sub-agent อยู่แล้ว:
+
+```yaml
+parent_execution_id:  ใช้กับ sub-agent / delegation — สิทธิ์ของลูกต้องไม่กว้างกว่าพ่อ
+parallel_substates:   งานคู่ขนานทำโดยสร้าง execution ลูก ไม่ใช่ substate ในตัวเดียว
+```
+
+**แต่ API ของ adkcode มองไม่เห็น sub-agent จากภายนอก** — `server/api.py` วน `runner.run_async()`
+แล้วเก็บเฉพาะ `event.is_final_response()` · event ระหว่างทาง (ซึ่ง ADK ใส่ `author` เป็นชื่อ agent มาด้วย)
+ถูกทิ้งไป HTTP จึงคืนแค่ข้อความสุดท้ายก้อนเดียว
+
+`execution/v1` เขียนกรณีนี้ไว้แล้วที่ `observability_depth`:
+
+> external provider มักให้ได้แค่ turn — consumer ต้องยอมรับ trace ที่ไม่มี step ย่อย
+> **ห้ามถือว่า execution ที่ไม่มี step คือ execution ที่ไม่ได้ทำอะไร**
+
+adapter จึงประกาศ **`observabilityDepth: "turn"` ตามความจริง — ไม่แต่ง event ปลอมขึ้นมา**
+
+### ทางไป `step` มีอยู่ชัด
+
+ให้ `api.py` ส่ง `author` ของแต่ละ event ออกมา (SSE หรือใส่ใน response) แล้ว adapter
+สร้าง execution ลูกที่มี `parent_execution_id` ได้ทันที — แต่ต้องแก้ฝั่ง server
+ซึ่งอยู่บน `main` ที่ freeze ไว้ที่ `v1-final` จึงเป็นงานของ Phase ถัดไป ไม่ใช่ตอนนี้
+
+## สิ่งที่ต่างจาก engine อื่น
+
+| | adkcode | อื่น ๆ |
+| --- | --- | --- |
+| `createSession` | **ต้องมี `user_id`** — ADK ผูก session กับผู้ใช้ | ไม่ต้องรู้จักผู้ใช้ |
+| session ที่ยุ่งอยู่ | **ตอบ `409`** ตรง ๆ | ใช้คิวของ core กันไว้ |
+| timeout | ไม่มีคำตอบบางส่วนให้ดึง | `opencode` มี `fetchLastAssistantMessage` |
+| **GROUP CHAT instruction** | **ไม่มี** (feature 4.7 — ตัวเดียวใน 9) | มีครบ |
+| question guard | ห้าม "ถามกลับ" เฉย ๆ | `opencode` ระบุเจาะจงว่าห้ามใช้ question **tool** |
+
+### ⚠️ `[SKIP]` ของ adkcode ยิงได้แค่บังเอิญ
+
+ฝั่ง bot ของ v1 **เช็ค `[SKIP]`** อยู่ แต่ prefix **ไม่เคยบอก model ให้ตอบ `[SKIP]`**
+— ตรวจหาคำตอบที่ไม่เคยสั่งให้ผลิต
+
+ยกมาเหมือนเดิมเพื่อไม่เปลี่ยนพฤติกรรมเงียบ ๆ · เปิดได้ด้วย `groupChatInstruction: true`
+
+```ts
+new AdkcodeAdapter({ url, groupChatInstruction: true })   // ให้ [SKIP] ทำงานจริง
+```
+
+## gap ของ core ที่ปิดไปด้วย — `409` → `conflict`
+
+เดิม `409 Session is busy` ตกเป็น `internal` แล้วผู้ใช้ได้ข้อความ *"เกิดข้อผิดพลาดครับ: …"*
+ทั้งที่ `error/v1` มี category `conflict` อยู่แล้วและมันแค่ต้องรอ
+
+เพิ่ม rule `runtime.session_busy` → `conflict` · `retryable: true` ·
+*"กำลังตอบข้อความก่อนหน้าอยู่ครับ รอสักครู่แล้วส่งใหม่"*
+
+> ⚠️ **ห้ามใช้ `"409"` เป็น needle** — characterization test จับได้ว่ามันไปตรงกับ
+> `ECONNREFUSED 127.0.0.1:4096` (เลข port ของ opencode มี `409` อยู่ข้างใน)
+> มี regression test ล็อกไว้แล้ว
+
+## test
+
+```bash
+npm test --prefix packages/adapter-adkcode
+```
+
+12 test · fake server ที่เคารพ `AbortSignal` จริง ครอบ 409 · 404 retry · timeout · `/new` · `/abort`
+
+## ยังไม่ได้ทำ
+
+- ยังไม่ได้ยิง adkcode ตัวจริง — ต้องมี Google ADC หรือ `GOOGLE_API_KEY`
+  (มี container `legal-services` รันอยู่บนเครื่องนี้ แต่เป็นของลูกค้า ไม่ควรไปยุ่ง)
+- sub-agent execution tree — รอ `api.py` ส่ง `author` ออกมา
+- MCP ของ adkcode (`mcp_config.py`) โหลด `mcp.json` ได้แต่ไม่มี template ไหน ship มา

--- a/packages/adapter-adkcode/package.json
+++ b/packages/adapter-adkcode/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@botforge/adapter-adkcode",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "description": "RuntimePort สำหรับ adkcode — Google ADK multi-agent หลัง FastAPI",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": { "@botforge/core": "^0.0.1" },
+  "devDependencies": { "@types/node": "^22", "typescript": "^5.7.0" }
+}

--- a/packages/adapter-adkcode/src/adapter.test.ts
+++ b/packages/adapter-adkcode/src/adapter.test.ts
@@ -1,0 +1,158 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { AdkcodeAdapter } from "./adapter.ts"
+import { SessionBusyError } from "./client.ts"
+import { buildPrefix, QUESTION_GUARD, GROUP_CHAT_INSTRUCTION } from "./prompt.ts"
+
+interface Req { method: string; path: string; body?: any }
+
+function fakeServer(handler: (r: Req) => { status?: number; body?: unknown } | Promise<{ status?: number; body?: unknown }>) {
+  const seen: Req[] = []
+  const abortError = () => { const e = new Error("The operation was aborted"); e.name = "AbortError"; return e }
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input))
+    const req: Req = { method: init?.method ?? "GET", path: url.pathname, body: init?.body ? JSON.parse(String(init.body)) : undefined }
+    seen.push(req)
+    const settled = await Promise.race([
+      Promise.resolve(handler(req)),
+      new Promise<never>((_, reject) => {
+        const s = init?.signal
+        if (!s) return
+        if (s.aborted) return reject(abortError())
+        s.addEventListener("abort", () => reject(abortError()), { once: true })
+      }),
+    ])
+    const { status = 200, body = {} } = settled
+    return new Response(JSON.stringify(body), { status }) as any
+  }
+  return { seen, fetchImpl }
+}
+
+const make = (fetchImpl: typeof fetch, over = {}) =>
+  new AdkcodeAdapter({ url: "http://server:8000", fetchImpl, promptTimeoutMs: 800, ...over })
+
+const prompt = (over = {}) => ({
+  sessionKey: "line-c1", userId: "U4af4980629f1b2c3", text: "สวัสดี", isGroup: false, ...over,
+}) as any
+
+test("สร้าง session พร้อม user_id — ADK ผูก session กับผู้ใช้", async () => {
+  const { seen, fetchImpl } = fakeServer((r) =>
+    r.path === "/session" ? { body: { id: "s1" } } : { body: { result: "ตอบ" } })
+  const out = await make(fetchImpl).sendPrompt(prompt())
+  assert.equal(out.result, "ตอบ")
+  assert.deepEqual(seen[0]!.body, { user_id: "U4af4980629f1b2c3" },
+    "engine อื่น createSession ไม่ต้องรู้จักผู้ใช้ ADK ต้องรู้")
+})
+
+test("session ถูกใช้ซ้ำ ไม่สร้างใหม่ทุกข้อความ", async () => {
+  let made = 0
+  const { fetchImpl } = fakeServer((r) =>
+    r.path === "/session" && r.method === "POST" ? { body: { id: `s${++made}` } } : { body: { result: "ตอบ" } })
+  const a = make(fetchImpl)
+  await a.sendPrompt(prompt())
+  await a.sendPrompt(prompt())
+  assert.equal(made, 1)
+  assert.deepEqual(a.sessionInfo("line-c1"), { sessionId: "s1" })
+})
+
+test("409 → SessionBusyError และ core แปลงเป็น conflict ไม่ใช่ internal", async () => {
+  const { fetchImpl } = fakeServer((r) =>
+    r.path === "/session" && r.method === "POST"
+      ? { body: { id: "s1" } }
+      : { status: 409, body: { detail: "Session is busy" } })
+  await assert.rejects(make(fetchImpl).sendPrompt(prompt()), SessionBusyError)
+
+  const { classify, toUserMessage } = await import("@botforge/core/errors")
+  const err = new SessionBusyError("line-c1")
+  assert.equal(classify(err).category, "conflict")
+  assert.equal(classify(err).retryable, true)
+  assert.ok(toUserMessage(err).includes("รอสักครู่"))
+})
+
+test("404 → สร้าง session ใหม่แล้วลองอีกครั้ง (feature 2.6)", async () => {
+  let made = 0, first = true
+  const { seen, fetchImpl } = fakeServer((r) => {
+    if (r.path === "/session" && r.method === "POST") return { body: { id: `s${++made}` } }
+    if (first) { first = false; return { status: 404, body: { detail: "Session not found" } } }
+    return { body: { result: "ตอบหลัง retry" } }
+  })
+  assert.equal((await make(fetchImpl).sendPrompt(prompt())).result, "ตอบหลัง retry")
+  assert.equal(made, 2)
+  assert.equal(seen.filter((r) => r.path.endsWith("/message")).length, 2)
+})
+
+test("timeout → timedOut และ abort ถูกส่ง · ไม่มีคำตอบบางส่วนให้ดึง", async () => {
+  const { seen, fetchImpl } = fakeServer(async (r) => {
+    if (r.path === "/session" && r.method === "POST") return { body: { id: "s1" } }
+    if (r.path === "/session/s1/abort") return { body: {} }
+    await new Promise((res) => setTimeout(res, 3000))
+    return { body: {} }
+  })
+  const out = await make(fetchImpl, { promptTimeoutMs: 80 }).sendPrompt(prompt())
+  assert.equal(out.timedOut, true)
+  assert.equal(out.result, "", "adkcode ไม่มี fetchLastAssistantMessage แบบ opencode")
+  assert.ok(seen.some((r) => r.path === "/session/s1/abort"))
+})
+
+test("is_error จาก server ไหลผ่านมาให้ core แปลง", async () => {
+  const { fetchImpl } = fakeServer((r) =>
+    r.path === "/session" && r.method === "POST"
+      ? { body: { id: "s1" } }
+      : { body: { result: "Server 429: rate limit exceeded", is_error: true } })
+  const out = await make(fetchImpl).sendPrompt(prompt())
+  assert.equal(out.isError, true)
+  const { toUserMessage } = await import("@botforge/core/errors")
+  assert.equal(toUserMessage(out.result), "เกิน rate limit ครับ รอสักครู่แล้วลองใหม่")
+})
+
+test("result ว่าง → ข้อความมาตรฐาน", async () => {
+  const { fetchImpl } = fakeServer((r) =>
+    r.path === "/session" && r.method === "POST" ? { body: { id: "s1" } } : { body: {} })
+  assert.equal((await make(fetchImpl).sendPrompt(prompt())).result, "เสร็จแล้วครับ (ไม่มีข้อความตอบกลับ)")
+})
+
+test("/new ลบ session ฝั่ง server · /abort เรียก endpoint", async () => {
+  const { seen, fetchImpl } = fakeServer((r) =>
+    r.path === "/session" && r.method === "POST" ? { body: { id: "s1" } } : { body: { result: "ok" } })
+  const a = make(fetchImpl)
+  assert.equal(await a.abort("line-c1"), false)
+  await a.sendPrompt(prompt())
+  assert.equal(await a.abort("line-c1"), true)
+  await a.resetSession("line-c1")
+  assert.equal(a.sessionInfo("line-c1"), null)
+  assert.ok(seen.some((r) => r.method === "DELETE" && r.path === "/session/s1"))
+})
+
+test("ประกาศ observabilityDepth: turn ตามความจริง", () => {
+  const { fetchImpl } = fakeServer(() => ({ body: {} }))
+  const a = make(fetchImpl)
+  assert.equal(a.observabilityDepth, "turn",
+    "sub-agent มองไม่เห็นจากภายนอก — execution/v1 บอกว่าห้ามถือว่า execution ที่ไม่มี step คือไม่ได้ทำอะไร")
+  assert.equal(a.cancellation, "graceful")
+})
+
+// ── prompt ──
+
+test("prefix ของ adkcode — question guard คนละแบบกับ opencode", () => {
+  const p = buildPrefix({ userContext: "[User: สมชาย]", groupName: "ทีมกฎหมาย",
+    quotedMessageId: "m-1", isGroup: true, now: new Date("2026-08-23T07:30:05Z") })
+  assert.ok(p.startsWith(QUESTION_GUARD))
+  assert.ok(p.includes("Do NOT ask clarifying questions"))
+  assert.equal(p.includes("question tool"), false, "ของ opencode ระบุเจาะจงว่า question tool")
+  assert.ok(p.includes("[User: สมชาย] [Group: ทีมกฎหมาย] [Time: 2026-08-23 14:30:05+07:00]"))
+  assert.ok(p.includes("[Reply to message ID: m-1]"))
+})
+
+test("v1 ไม่มี GROUP CHAT instruction — [SKIP] จึงยิงได้แค่บังเอิญ", () => {
+  const v1 = buildPrefix({ isGroup: true, now: new Date("2026-08-23T07:30:05Z") })
+  assert.equal(v1.includes(GROUP_CHAT_INSTRUCTION), false,
+    "ยกมาตามจริง — adkcode เป็น engine เดียวใน 9 ที่ไม่มีข้อนี้ (feature 4.7)")
+
+  const opted = buildPrefix({ isGroup: true, groupChatInstruction: true, now: new Date("2026-08-23T07:30:05Z") })
+  assert.ok(opted.includes(GROUP_CHAT_INSTRUCTION), "เปิดได้ถ้าอยากให้ [SKIP] ทำงานจริง")
+})
+
+test("1:1 ไม่มี GROUP CHAT แม้เปิด option", () => {
+  const p = buildPrefix({ isGroup: false, groupChatInstruction: true, now: new Date("2026-08-23T07:30:05Z") })
+  assert.equal(p.includes(GROUP_CHAT_INSTRUCTION), false)
+})

--- a/packages/adapter-adkcode/src/adapter.ts
+++ b/packages/adapter-adkcode/src/adapter.ts
@@ -1,0 +1,143 @@
+/**
+ * AdkcodeAdapter — RuntimePort สำหรับ Google ADK หลัง FastAPI
+ *
+ * เป็น engine **ตัวเดียวใน 9 ที่เป็น multi-agent จริง**
+ * `root_agent` มี `sub_agents=[coder, reviewer, tester]` — หนึ่ง prompt แตกเป็นหลาย agent
+ *
+ * ## ทำไมยังปล่อย execution เดียว ไม่ใช่ tree
+ *
+ * `execution/v1` มี `parent_execution_id` กับกฎ `parallel_substates` รองรับ sub-agent อยู่แล้ว
+ * แต่ **API ของ adkcode มองไม่เห็น sub-agent จากภายนอก** — `api.py` วน `runner.run_async()`
+ * แล้วเก็บเฉพาะ `event.is_final_response()` ส่วน event ระหว่างทาง (ซึ่ง ADK ใส่ `author`
+ * เป็นชื่อ agent มาด้วย) ถูกทิ้ง · HTTP จึงคืนแค่ข้อความสุดท้ายก้อนเดียว
+ *
+ * `execution/v1` เขียนกรณีนี้ไว้แล้วที่ `observability_depth`:
+ *
+ *   > external provider มักให้ได้แค่ turn — consumer ต้องยอมรับ trace ที่ไม่มี step ย่อย
+ *   > **ห้ามถือว่า execution ที่ไม่มี step คือ execution ที่ไม่ได้ทำอะไร**
+ *
+ * adapter จึงประกาศ `observabilityDepth: "turn"` ตามความจริง **ไม่แต่ง event ปลอมขึ้นมา**
+ * ทางไป `step` มีอยู่ชัด (ให้ `api.py` ส่ง `author` ของ event ออกมา) แต่ต้องแก้ฝั่ง server
+ * ซึ่งอยู่บน `main` ที่ freeze แล้ว — บันทึกไว้ที่ README
+ */
+import type { PromptInput, RuntimeResult, RuntimePort } from "@botforge/core/router"
+import { AdkcodeClient, SessionBusyError, type AdkcodeConfig } from "./client.ts"
+import { buildPrefix } from "./prompt.ts"
+
+export interface AdkcodeAdapterOptions extends AdkcodeConfig {
+  promptTimeoutMs?: number
+  /** เปิด GROUP CHAT instruction ให้ `[SKIP]` ทำงานจริง — v1 ปิดอยู่ */
+  groupChatInstruction?: boolean
+  log?: (...args: unknown[]) => void
+}
+
+export class AdkcodeAdapter implements RuntimePort {
+  readonly client: AdkcodeClient
+  readonly #sessions = new Map<string, string>()
+  readonly #timeout: number
+  readonly #groupChat: boolean
+  readonly #log: (...args: unknown[]) => void
+
+  constructor(options: AdkcodeAdapterOptions) {
+    this.client = new AdkcodeClient(options)
+    this.#timeout = options.promptTimeoutMs ?? 120_000
+    this.#groupChat = options.groupChatInstruction ?? false
+    this.#log = options.log ?? (() => {})
+  }
+
+  /**
+   * สิ่งที่ประกาศได้ตาม `provider/v1/agent-provider`
+   * `turn` เพราะ sub-agent มองไม่เห็นจากภายนอก — ดู comment บนหัวไฟล์
+   */
+  readonly observabilityDepth = "turn" as const
+  readonly cancellation = "graceful" as const
+
+  sessionInfo(sessionKey: string): { sessionId: string } | null {
+    const id = this.#sessions.get(sessionKey)
+    return id ? { sessionId: id } : null
+  }
+
+  async resetSession(sessionKey: string): Promise<void> {
+    const id = this.#sessions.get(sessionKey)
+    if (id) await this.client.deleteSession(id).catch(() => {})
+    this.#sessions.delete(sessionKey)
+  }
+
+  async abort(sessionKey: string): Promise<boolean> {
+    const id = this.#sessions.get(sessionKey)
+    if (!id) return false
+    await this.client.abortSession(id)
+    return true
+  }
+
+  async #ensureSession(sessionKey: string, userId: string): Promise<string> {
+    const existing = this.#sessions.get(sessionKey)
+    if (existing) return existing
+    const created = await this.client.createSession(userId)
+    if (!created?.id) throw new Error("createSession ไม่คืน id")
+    this.#sessions.set(sessionKey, created.id)
+    return created.id
+  }
+
+  async sendPrompt(input: PromptInput): Promise<RuntimeResult> {
+    let sessionId = await this.#ensureSession(input.sessionKey, input.userId)
+    const prefix = buildPrefix({
+      userContext: input.userContext,
+      groupName: input.groupName,
+      quotedMessageId: input.quotedMessageId,
+      isGroup: input.isGroup,
+      groupChatInstruction: this.#groupChat,
+    })
+
+    try {
+      return await this.#send(sessionId, prefix + input.text)
+    } catch (err) {
+      // session หายฝั่ง server → สร้างใหม่แล้วลองอีกครั้ง (feature 2.6 มีครบทั้ง 9 engine)
+      if (isSessionGone(err)) {
+        this.#log("session หายฝั่ง server สร้างใหม่")
+        this.#sessions.delete(input.sessionKey)
+        sessionId = await this.#ensureSession(input.sessionKey, input.userId)
+        return await this.#send(sessionId, prefix + input.text)
+      }
+      throw err
+    }
+  }
+
+  async #send(sessionId: string, text: string): Promise<RuntimeResult> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.#timeout)
+    try {
+      const raw = await this.client.request(
+        "POST", `/session/${sessionId}/message`, { content: text }, controller.signal,
+      )
+      clearTimeout(timer)
+      return {
+        result: typeof raw?.result === "string" ? raw.result : "เสร็จแล้วครับ (ไม่มีข้อความตอบกลับ)",
+        ...(raw?.is_error ? { isError: true } : {}),
+      }
+    } catch (err) {
+      clearTimeout(timer)
+      if (err instanceof SessionBusyError) {
+        // 409 เป็นสถานะไม่ใช่ error ถาวร — ส่งต่อให้ core map เป็น error/v1 category `conflict`
+        // core ยังไม่มี rule สำหรับ conflict จึงตกเป็น internal · ดู README
+        throw err
+      }
+      if (isAbort(err)) {
+        // adkcode ไม่มีทางดึงคำตอบบางส่วน ต่างจาก opencode ที่มี fetchLastAssistantMessage
+        await this.client.abortSession(sessionId)
+        return { result: "", timedOut: true }
+      }
+      throw err
+    }
+  }
+}
+
+function isAbort(err: unknown): boolean {
+  const e = err as { name?: string; message?: string }
+  return e?.name === "AbortError" || (e?.message ?? "").includes("abort")
+}
+
+function isSessionGone(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg.includes("404") || msg.toLowerCase().includes("session not found")
+}

--- a/packages/adapter-adkcode/src/client.ts
+++ b/packages/adapter-adkcode/src/client.ts
@@ -1,0 +1,88 @@
+/**
+ * HTTP client ของ adkcode — FastAPI + Google ADK
+ *
+ * ยกมาจาก `adkcodeRequest()` ของ v1-final · logic เดียวกับ transport ของ engine อื่น
+ * ต่างแค่ base URL กับ prefix ของ error string (ดู current-state.md §4)
+ */
+export interface AdkcodeConfig {
+  url: string
+  /** `API_PASSWORD` ฝั่ง server → `Authorization` */
+  auth?: string
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}
+
+/** server ตอบ 409 เมื่อ session กำลังทำงานอยู่ — เป็นสถานะ ไม่ใช่ความผิดพลาดถาวร */
+export class SessionBusyError extends Error {
+  constructor(sessionId: string) {
+    super(`session ${sessionId} กำลังทำงานอยู่ (409 conflict)`)
+    this.name = "SessionBusyError"
+  }
+}
+
+export class AdkcodeClient {
+  readonly #url: string
+  readonly #auth: string | undefined
+  readonly #timeout: number
+  readonly #fetch: typeof fetch
+
+  constructor(config: AdkcodeConfig) {
+    this.#url = config.url.replace(/\/$/, "")
+    this.#auth = config.auth
+    this.#timeout = config.timeoutMs ?? 300_000
+    this.#fetch = config.fetchImpl ?? fetch
+  }
+
+  async request(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<any> {
+    const headers: Record<string, string> = {}
+    if (this.#auth) headers["Authorization"] = this.#auth
+    if (body !== undefined) headers["Content-Type"] = "application/json"
+
+    const resp = await this.#fetch(`${this.#url}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: signal ?? AbortSignal.timeout(this.#timeout),
+    })
+
+    const text = await resp.text()
+    if (resp.status === 409) throw new SessionBusyError(path)
+    if (!resp.ok) throw new Error(`ADKcode API ${resp.status}: ${text.slice(0, 300)}`)
+    try {
+      return JSON.parse(text)
+    } catch {
+      return text
+    }
+  }
+
+  /** ADK ผูก session กับ user — ต่างจาก engine อื่นที่ createSession ไม่ต้องรู้จักผู้ใช้ */
+  createSession(userId?: string): Promise<{ id: string }> {
+    return this.request("POST", "/session", { user_id: userId })
+  }
+
+  sessionInfo(sessionId: string): Promise<{ status?: string } | null> {
+    return this.request("GET", `/session/${sessionId}`).catch(() => null)
+  }
+
+  deleteSession(sessionId: string): Promise<unknown> {
+    return this.request("DELETE", `/session/${sessionId}`)
+  }
+
+  async abortSession(sessionId: string): Promise<void> {
+    await this.request("POST", `/session/${sessionId}/abort`).catch(() => {})
+  }
+
+  async waitUntilReady(maxRetries = 30, delayMs = 2000, log: (m: string) => void = () => {}): Promise<boolean> {
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const headers: Record<string, string> = {}
+        if (this.#auth) headers["Authorization"] = this.#auth
+        const resp = await this.#fetch(`${this.#url}/health`, { headers, signal: AbortSignal.timeout(3000) })
+        if (resp.ok) { log("adkcode พร้อมแล้ว"); return true }
+      } catch { /* ยังไม่พร้อม */ }
+      log(`รอ adkcode... (${i + 1}/${maxRetries})`)
+      await new Promise((r) => setTimeout(r, delayMs))
+    }
+    return false
+  }
+}

--- a/packages/adapter-adkcode/src/index.ts
+++ b/packages/adapter-adkcode/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./client.ts"
+export * from "./prompt.ts"
+export * from "./adapter.ts"

--- a/packages/adapter-adkcode/src/prompt.ts
+++ b/packages/adapter-adkcode/src/prompt.ts
@@ -1,0 +1,42 @@
+/**
+ * ประกอบ prompt prefix แบบ adkcode
+ *
+ * ยกมาจาก `sendPrompt()` ของ `bot-service-adkcode` ที่ v1-final ทุกตัวอักษร
+ *
+ * ⚠️ **ไม่มี GROUP CHAT instruction** — ต่างจาก opencode · codex · claude-code
+ *    แต่ฝั่ง bot ของ adkcode **ยังเช็ค `[SKIP]`** อยู่
+ *    แปลว่า v1 ตรวจหาคำตอบที่ไม่เคยบอก model ให้ตอบ — เส้นทางนั้นยิงได้แค่โดยบังเอิญ
+ *    (ตรงกับ feature-matrix ข้อ 4.7 ที่ adkcode เป็น ❌ ตัวเดียว)
+ *
+ *    ยกมาเหมือนเดิมเพื่อไม่เปลี่ยนพฤติกรรมเงียบ ๆ · เปิดผ่าน `groupChatInstruction` ได้
+ *
+ * question guard ก็ต่างจาก opencode — ของ adkcode ห้าม "ถามกลับ" เฉย ๆ
+ * ส่วนของ opencode ระบุเจาะจงว่าห้ามใช้ question **tool**
+ */
+import { getTimeContext } from "@botforge/core/context"
+
+export const QUESTION_GUARD =
+  "[IMPORTANT: Always respond directly with text. Do NOT ask clarifying questions. If unsure, make your best guess and explain your assumptions.]"
+
+export const GROUP_CHAT_INSTRUCTION =
+  "[GROUP CHAT: You are in a group chat. If this message is clearly NOT directed at you (just people chatting with each other, unrelated conversations), respond with exactly [SKIP] and nothing else. If the message mentions you, asks a question, or could be directed at you, respond normally.]"
+
+export interface PrefixInput {
+  userContext?: string
+  groupName?: string
+  quotedMessageId?: string
+  isGroup: boolean
+  /** เปิดเพื่อให้ `[SKIP]` ทำงานจริง — v1 ปิดอยู่ (ค่าเริ่มต้นคือของ v1) */
+  groupChatInstruction?: boolean
+  now?: Date
+}
+
+export function buildPrefix(input: PrefixInput): string {
+  let out = `${QUESTION_GUARD}\n\n`
+  if (input.userContext) out += `${input.userContext} `
+  if (input.groupName) out += `[Group: ${input.groupName}] `
+  out += `${getTimeContext(input.now)}\n\n`
+  if (input.quotedMessageId) out += `[Reply to message ID: ${input.quotedMessageId}]\n\n`
+  if (input.isGroup && input.groupChatInstruction) out += `${GROUP_CHAT_INSTRUCTION}\n\n`
+  return out
+}

--- a/packages/adapter-adkcode/tsconfig.json
+++ b/packages/adapter-adkcode/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2024"
+    ],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -60,7 +60,7 @@ npm run typecheck --prefix packages/core
 > เปลี่ยน Codex → Claude โดยไม่แก้ Channel ✅ — runtime อยู่หลัง `RuntimePort` ตัวเดียว
 > เปลี่ยน LINE → Web โดยไม่แก้ Runtime ✅ — [`channel-web`](../channel-web/) ใช้ `adapter-opencode` ตัวเดิมโดยไม่แก้อะไร ยืนยันกับ model จริงแล้ว
 
-adapter ที่มีแล้ว 3 shape: [`adapter-opencode`](../adapter-opencode/) (HTTP) · [`adapter-codex`](../adapter-codex/) (stdio JSON-RPC) · [`adapter-claude`](../adapter-claude/) (in-process SDK) —
+adapter ที่มีแล้ว 4 ตัว 4 shape: [`adapter-opencode`](../adapter-opencode/) (HTTP) · [`adapter-codex`](../adapter-codex/) (stdio JSON-RPC) · [`adapter-claude`](../adapter-claude/) (in-process SDK) · [`adapter-adkcode`](../adapter-adkcode/) (HTTP + multi-agent) —
 พิสูจน์แล้วด้วย `e2e.test.ts` ที่วิ่งผ่าน HTTP จริง และ `scripts/smoke-opencode.ts`
 ที่ยิง OpenCode server จริงได้ด้วย model ฟรี
 

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -135,6 +135,19 @@ test("โควต้าหมดของ OKMD — เพิ่มจาก v1 
   assert.equal(classify("Server 401: unauthorized").category, "authentication")
 })
 
+test("session busy → conflict ไม่ใช่ internal", () => {
+  const e = classify("ADKcode API 409: Session is busy")
+  assert.equal(e.code, "runtime.session_busy")
+  assert.equal(e.category, "conflict")
+  assert.equal(e.retryable, true, "รอแล้วส่งใหม่ได้")
+  assert.ok(toUserMessage("session line-c1 กำลังทำงานอยู่ (409 conflict)").includes("รอสักครู่"))
+  // ไม่ไปทับ rate limit
+  assert.equal(classify("Server 429: rate limit").category, "rate_limited")
+  // regression — เคยใช้ "409" เป็น needle แล้วไปจับเลข port ของ opencode เข้า
+  assert.equal(classify("ECONNREFUSED 127.0.0.1:4096").code, "runtime.unknown",
+    "เลข port ที่มี 409 อยู่ข้างในต้องไม่ถูกจับเป็น session busy")
+})
+
 test("renderThai รับ error/v1 object ที่ code ไม่รู้จักได้", () => {
   const foreign = { code: "odoo.sale.locked", category: "conflict" as const, message: "record locked", retryable: false }
   assert.equal(renderThai(foreign), "เกิดข้อผิดพลาดครับ: record locked")

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -84,6 +84,20 @@ const RULES: ReadonlyArray<{
     thai: "AI ใช้เวลานานเกินไปครับ ลองพิมพ์ /new แล้วถามใหม่",
   },
   {
+    // runtime กำลังทำงานอยู่กับ session นี้ — เป็นสถานะ ไม่ใช่ความผิดพลาดถาวร
+    // adkcode ตอบ 409 ตรง ๆ · engine อื่นใช้คิวของ core กันไว้แล้วจึงไม่ค่อยเจอ
+    // `conflict` มีอยู่ใน error/v1 Category อยู่แล้ว — เพิ่มตอนทำ adapter-adkcode
+    //
+    // ⚠️ **ห้ามใช้ `"409"` เป็น needle** — characterization test จับได้ว่ามันไปตรงกับ
+    //    `ECONNREFUSED 127.0.0.1:4096` (เลข port ของ opencode มี `409` อยู่ข้างใน)
+    //    ต้องจับด้วยข้อความที่ระบุความหมายจริงเท่านั้น
+    needles: ["session is busy", "กำลังทำงานอยู่"],
+    code: "runtime.session_busy",
+    category: "conflict",
+    retryable: true,
+    thai: "กำลังตอบข้อความก่อนหน้าอยู่ครับ รอสักครู่แล้วส่งใหม่",
+  },
+  {
     needles: ["401", "403", "auth", "unauthorized"],
     code: "runtime.unauthenticated",
     category: "authentication",


### PR DESCRIPTION
adapter ตัวที่สี่ — **engine เดียวใน 9 ที่เป็น multi-agent จริง**

```python
root_agent = Agent(..., sub_agents=[coder, reviewer, tester])
```

## ทำไมยังปล่อย execution เดียว ไม่ใช่ tree

`execution/v1` รองรับ sub-agent อยู่แล้ว (`parent_execution_id` + กฎ `parallel_substates`)

**แต่ API ของ adkcode มองไม่เห็น sub-agent จากภายนอก** — `api.py` วน `runner.run_async()` แล้วเก็บเฉพาะ `event.is_final_response()` · event ระหว่างทาง (ซึ่ง ADK ใส่ `author` เป็นชื่อ agent มาด้วย) **ถูกทิ้ง**

`execution/v1` เขียนกรณีนี้ไว้แล้ว:

> external provider มักให้ได้แค่ turn — consumer ต้องยอมรับ trace ที่ไม่มี step ย่อย
> **ห้ามถือว่า execution ที่ไม่มี step คือ execution ที่ไม่ได้ทำอะไร**

adapter จึงประกาศ **`observabilityDepth: "turn"` ตามความจริง — ไม่แต่ง event ปลอมขึ้นมา**

ทางไป `step` มีอยู่ชัด: ให้ `api.py` ส่ง `author` ออกมา แล้วสร้าง execution ลูกได้ทันที — แต่ต้องแก้ฝั่ง server ซึ่งอยู่บน `main` ที่ freeze ไว้

## ต่างจาก engine อื่น

| | adkcode | อื่น ๆ |
| --- | --- | --- |
| `createSession` | **ต้องมี `user_id`** | ไม่ต้องรู้จักผู้ใช้ |
| session ยุ่งอยู่ | **ตอบ `409`** | ใช้คิวของ core กันไว้ |
| timeout | ไม่มีคำตอบบางส่วนให้ดึง | `opencode` มี |
| GROUP CHAT instruction | **ไม่มี** (feature 4.7) | มีครบ |

### ⚠️ `[SKIP]` ของ adkcode ยิงได้แค่บังเอิญ

ฝั่ง bot **เช็ค `[SKIP]`** แต่ prefix **ไม่เคยบอก model ให้ตอบ** — ตรวจหาคำตอบที่ไม่เคยสั่งให้ผลิต

ยกมาเหมือนเดิม · เปิดได้ด้วย `groupChatInstruction: true`

## gap ของ core ที่ปิดไปด้วย — `409` → `conflict`

เดิม `409 Session is busy` ตกเป็น `internal` แล้วผู้ใช้ได้ *"เกิดข้อผิดพลาดครับ: …"* ทั้งที่ `error/v1` มี `conflict` อยู่แล้วและมันแค่ต้องรอ

เพิ่ม `runtime.session_busy` → `conflict` · `retryable: true`

> ⚠️ **characterization test จับได้ว่าใช้ `"409"` เป็น needle ไม่ได้** — มันไปตรงกับ `ECONNREFUSED 127.0.0.1:4096` (เลข port ของ opencode มี `409` อยู่ข้างใน) · แคบ needle แล้ว + regression test ล็อก

conformance ครอบคลุม **8 category** แล้ว (เพิ่ม `conflict`)

## ยังไม่ได้ทำ

ยังไม่ได้ยิง adkcode ตัวจริง — ต้องมี Google ADC/API key · มี container `legal-services` รันอยู่บนเครื่องแต่เป็นของลูกค้า ไม่ควรไปยุ่ง

---

**222 test** (core 112 + opencode 38 + codex 27 + claude 22 + adkcode 12 + web 12)
