### PR TITLE
feat: channel-line + apps/line-bot — V2 ส่งมอบได้เป็นครั้งแรก

### DIFF
--- a/apps/line-bot/.env.example
+++ b/apps/line-bot/.env.example
@@ -1,0 +1,31 @@
+# ── ตัวตนใน ecosystem — ห้ามเดา event/v1 บังคับให้ประกาศ ──
+BOTFORGE_TENANT_ID=legal             # ลูกค้า
+BOTFORGE_WORKSPACE_ID=legal-opencode # bot หนึ่งตัว
+
+# ── LINE ──
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_ACCESS_TOKEN=
+LINE_OA_URL=
+BOT_NAME=OpenCode Bot
+PORT=3000
+
+# ── runtime: opencode | codex | claude | adkcode ──
+BOTFORGE_RUNTIME=opencode
+WORKSPACE_DIR=/workspace
+PROMPT_TIMEOUT_MS=120000
+
+# opencode
+OPENCODE_URL=http://opencode:4096
+OPENCODE_PASSWORD=
+
+# codex  (ต้องมี codex CLI + ล็อกอินแล้ว)
+# CODEX_MODEL=o4-mini
+
+# claude (ต้องมี ANTHROPIC_API_KEY หรือ ~/.claude)
+# CLAUDE_MODEL=sonnet
+# CLAUDE_MAX_TURNS=10
+# CLAUDE_MAX_BUDGET_USD=1.00
+
+# adkcode
+# ADKCODE_URL=http://server:8000
+# SERVER_PASSWORD=

--- a/apps/line-bot/Dockerfile
+++ b/apps/line-bot/Dockerfile
@@ -1,0 +1,25 @@
+# LINE bot ของ V2 — ประกอบจาก workspace ทั้งก้อน
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# ติดตั้งจาก manifest ก่อน เพื่อให้ layer cache ทำงานตอนแก้โค้ด
+COPY package.json ./
+COPY packages/core/package.json             packages/core/
+COPY packages/channel-line/package.json     packages/channel-line/
+COPY packages/adapter-opencode/package.json packages/adapter-opencode/
+COPY packages/adapter-codex/package.json    packages/adapter-codex/
+COPY packages/adapter-claude/package.json   packages/adapter-claude/
+COPY packages/adapter-adkcode/package.json  packages/adapter-adkcode/
+COPY apps/line-bot/package.json             apps/line-bot/
+RUN npm install --omit=dev --workspaces --include-workspace-root
+
+COPY packages/ packages/
+COPY apps/line-bot/ apps/line-bot/
+
+EXPOSE 3000
+# --experimental-strip-types รัน TypeScript ตรง ๆ ไม่ต้องมี build step
+CMD ["node", "--experimental-strip-types", "apps/line-bot/src/main.ts"]

--- a/apps/line-bot/README.md
+++ b/apps/line-bot/README.md
@@ -1,0 +1,75 @@
+# @botforge/line-bot
+
+**LINE bot ที่ deploy ได้ — ชิ้นที่ทำให้ V2 ส่งมอบอะไรได้เป็นครั้งแรก**
+
+ก่อนหน้านี้ V2 มี library ครบแต่ไม่มีอะไรประกอบเป็น service
+`channel-web` มี HTTP server เต็มตัวตั้งแต่แรก ส่วน **LINE ซึ่งเป็น channel ของทั้ง 14 bot มีแค่ primitive**
+
+## รัน
+
+```bash
+cp apps/line-bot/.env.example apps/line-bot/.env   # แล้วเติมค่า
+npm start --prefix apps/line-bot
+```
+
+```bash
+docker build -f apps/line-bot/Dockerfile -t botforge-line-bot .
+docker run --env-file apps/line-bot/.env -p 3000:3000 botforge-line-bot
+```
+
+webhook URL คือ `https://<domain>/webhook`
+
+## เลือก runtime ด้วย env ตัวเดียว
+
+```bash
+BOTFORGE_RUNTIME=opencode   # หรือ codex · claude · adkcode
+```
+
+`main.ts` **ไม่มี logic ของ LINE หรือของ runtime อยู่เลย** — เป็นแค่ตัวต่อสาย
+`config.ts` เป็นจุดเดียวที่รู้ว่า adapter ตัวไหนต้องการ env อะไร และ `import` แบบ lazy
+เพื่อไม่ให้ต้องโหลด SDK ของ engine ที่ไม่ได้ใช้
+
+### ค่าเริ่มต้นต่อ engine ยกมาจาก v1 ตามจริง
+
+| | `opencode` | อื่น ๆ |
+| --- | --- | --- |
+| `userContextFormat` | `verbose` — `[User Info: ชื่อ (messages: n)]` | `standard` — `[User: ชื่อ]` |
+| `lengthTruncationNotice` | ปิด — ใช้กลไก `_truncated` แทน | เปิด |
+
+## ยืนยันแล้วกับ model จริง
+
+สตาร์ทจริงต่อ OpenCode server แล้วยิง webhook ที่เซ็นถูกต้อง:
+
+```
+POST /webhook → 200 OK (67 ms — ตอบทันทีไม่รอ model)
+signature ผิด → 403 Invalid signature
+
+audit event (event/v1)
+   1 STATE_TRANSITION   pending→queued     tenant=legal channel=line
+   2 EXECUTION_STARTED                     tenant=legal channel=line
+   3 STATE_TRANSITION   running→succeeded  tenant=legal channel=line
+```
+
+**ตอบ 200 ใน 67 ms** โดยไม่รอ model — LINE จะได้ไม่ retry (พฤติกรรมของ v1)
+
+> ทดสอบด้วย LINE token ปลอม การส่งกลับจึงได้ 401 แล้ว **fallback จาก `reply` ไป `push` ทำงานจริง**
+> ซึ่งก่อนหน้านี้พิสูจน์ได้แค่ใน test · ขั้นสุดท้ายที่ยังไม่ได้ยืนยันคือส่งถึง LINE จริง ต้องมี token ของจริง
+
+## audit event
+
+เขียนลง **stdout เป็น JSON บรรทัดละใบ** ตาม `event/v1`
+ยังไม่ได้ส่งเข้า ecosystem — เปลี่ยนปลายทางได้ที่ `sink` ใน `main.ts` โดยไม่แตะที่อื่น
+
+## config ที่ขาดไม่ได้
+
+`BOTFORGE_TENANT_ID` และ `BOTFORGE_WORKSPACE_ID` **บังคับ** — `event/v1` เขียนไว้ว่า
+*"event ที่ resolve tenant ไม่ได้ ให้ reject ที่ intake ห้ามเดา tenant ให้"*
+
+ขาดแล้ว process จบด้วย **exit code 2** พร้อมบอกว่าขาดอะไร ไม่ใช่สตาร์ทแล้วปล่อย event ที่ผิด
+
+## ยังไม่ได้ทำ
+
+- ยังไม่ได้ยิงกับ LINE channel จริง — ต้องมี channel secret/token ของจริง
+- ไม่มี `docker-compose.yml` — v1 มี 3 container (bot + server + tunnel) · ตัวนี้ยังเป็น container เดียว
+- `botforge new` ยังสร้าง project แบบ V2 ไม่ได้ — ยังไม่มี template ที่ใช้ `packages/`
+- ยังไม่มีเส้นทางย้าย 14 bot จาก V1 มา V2

--- a/apps/line-bot/package.json
+++ b/apps/line-bot/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@botforge/line-bot",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "description": "LINE bot ที่ deploy ได้ — ประกอบ core + channel-line + adapter ตาม env",
+  "scripts": {
+    "start": "node --experimental-strip-types src/main.ts",
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@botforge/core": "^0.0.1",
+    "@botforge/channel-line": "^0.0.1",
+    "@botforge/adapter-opencode": "^0.0.1",
+    "@botforge/adapter-codex": "^0.0.1",
+    "@botforge/adapter-claude": "^0.0.1",
+    "@botforge/adapter-adkcode": "^0.0.1",
+    "@line/bot-sdk": "^9.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/line-bot/src/config.test.ts
+++ b/apps/line-bot/src/config.test.ts
@@ -1,0 +1,66 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { readConfig, createRuntime, ConfigError, RUNTIMES } from "./config.ts"
+
+const base = {
+  BOTFORGE_TENANT_ID: "legal",
+  BOTFORGE_WORKSPACE_ID: "legal-opencode",
+  LINE_CHANNEL_SECRET: "secret",
+  LINE_CHANNEL_ACCESS_TOKEN: "token",
+}
+
+test("อ่าน config ครบและตั้งค่าเริ่มต้นถูก", () => {
+  const c = readConfig(base)
+  assert.equal(c.runtimeName, "opencode", "ค่าเริ่มต้นคือ engine ของ 9 ใน 14 bot")
+  assert.equal(c.port, 3000)
+  assert.deepEqual(c.scope, { tenant_id: "legal", workspace_id: "legal-opencode" })
+})
+
+test("ขาด env ที่จำเป็น → ConfigError พร้อมบอกว่าขาดอะไร", () => {
+  for (const key of ["LINE_CHANNEL_SECRET", "LINE_CHANNEL_ACCESS_TOKEN"]) {
+    const env = { ...base }
+    delete (env as any)[key]
+    assert.throws(() => readConfig(env), (e: any) => e instanceof ConfigError && e.message.includes(key))
+  }
+})
+
+test("ขาด tenant/workspace → MissingScopeError ของ core ไม่ใช่เดาให้", () => {
+  const env = { ...base }
+  delete (env as any).BOTFORGE_TENANT_ID
+  assert.throws(() => readConfig(env), /BOTFORGE_TENANT_ID/)
+})
+
+test("BOTFORGE_RUNTIME ที่ไม่รองรับ → บอกตัวเลือกที่มี", () => {
+  assert.throws(
+    () => readConfig({ ...base, BOTFORGE_RUNTIME: "ไม่มีจริง" }),
+    (e: any) => e instanceof ConfigError && RUNTIMES.every((r) => e.message.includes(r)),
+  )
+})
+
+test("ค่าเริ่มต้นต่อ engine ยกมาจาก v1 ตามจริง", () => {
+  const oc = readConfig({ ...base, BOTFORGE_RUNTIME: "opencode" })
+  assert.equal(oc.userContextFormat, "verbose", "opencode ใช้ [User Info: …]")
+  assert.equal(oc.lengthTruncationNotice, false, "opencode ไม่ใช้กลไกนี้")
+
+  for (const r of ["codex", "claude", "adkcode"] as const) {
+    const c = readConfig({ ...base, BOTFORGE_RUNTIME: r })
+    assert.equal(c.userContextFormat, "standard", r)
+    assert.equal(c.lengthTruncationNotice, true, r)
+  }
+})
+
+test("createRuntime สร้าง adapter ได้ทุกตัวโดยไม่ต้องมี server จริง", async () => {
+  for (const r of RUNTIMES) {
+    // claude ต้องมี SDK ตอน sendPrompt แต่ตอน construct ยังไม่โหลด
+    const runtime = await createRuntime(readConfig({ ...base, BOTFORGE_RUNTIME: r }), {
+      ...base, CODEX_BIN: "/bin/true",
+    })
+    assert.equal(typeof runtime.sendPrompt, "function", r)
+  }
+})
+
+test("BOT_NAME และ PORT override ได้", () => {
+  const c = readConfig({ ...base, BOT_NAME: "ทีมกฎหมาย Bot", PORT: "8080" })
+  assert.equal(c.botName, "ทีมกฎหมาย Bot")
+  assert.equal(c.port, 8080)
+})

--- a/apps/line-bot/src/config.ts
+++ b/apps/line-bot/src/config.ts
@@ -1,0 +1,113 @@
+/**
+ * อ่าน config จาก env แล้วประกอบ runtime
+ *
+ * แยกจาก `main.ts` เพราะ **การเลือก adapter คือจุดที่พลาดง่ายที่สุด** และควรทดสอบได้
+ * โดยไม่ต้องสตาร์ท server หรือมี LINE token
+ */
+import { resolveScope, type Scope } from "@botforge/core/identity"
+import type { RuntimePort } from "@botforge/core/router"
+import type { UserContextFormat } from "@botforge/core/context"
+
+export const RUNTIMES = ["opencode", "codex", "claude", "adkcode"] as const
+export type RuntimeName = (typeof RUNTIMES)[number]
+
+export interface BotConfig {
+  scope: Scope
+  runtimeName: RuntimeName
+  channelSecret: string
+  channelAccessToken: string
+  port: number
+  botName: string
+  lineOaUrl: string
+  workspaceDir: string
+  promptTimeoutMs: number
+  /** `opencode` ใช้ `[User Info: …]` ส่วนที่เหลือใช้ `[User: …]` */
+  userContextFormat: UserContextFormat
+  /** `opencode` ไม่ใช้กลไกต่อท้ายว่าโดนตัดตามความยาว */
+  lengthTruncationNotice: boolean
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) { super(message); this.name = "ConfigError" }
+}
+
+function required(env: Record<string, string | undefined>, key: string): string {
+  const v = env[key]
+  if (!v) throw new ConfigError(`ต้องตั้ง ${key}`)
+  return v
+}
+
+export function readConfig(env: Record<string, string | undefined>): BotConfig {
+  const runtimeName = (env.BOTFORGE_RUNTIME ?? "opencode") as RuntimeName
+  if (!RUNTIMES.includes(runtimeName)) {
+    throw new ConfigError(
+      `BOTFORGE_RUNTIME "${runtimeName}" ไม่รองรับ — เลือกจาก ${RUNTIMES.join(" · ")}`,
+    )
+  }
+  // resolveScope โยนเองถ้าขาด — event/v1 ห้ามเดา tenant
+  const scope = resolveScope(env)
+
+  return {
+    scope,
+    runtimeName,
+    channelSecret: required(env, "LINE_CHANNEL_SECRET"),
+    channelAccessToken: required(env, "LINE_CHANNEL_ACCESS_TOKEN"),
+    port: Number(env.PORT ?? 3000),
+    botName: env.BOT_NAME ?? `${runtimeName} Bot`,
+    lineOaUrl: env.LINE_OA_URL ?? "",
+    workspaceDir: env.WORKSPACE_DIR ?? "/workspace",
+    promptTimeoutMs: Number(env.PROMPT_TIMEOUT_MS ?? 120_000),
+    // ยกค่าเริ่มต้นของแต่ละ engine มาจาก v1 ตามจริง
+    userContextFormat: runtimeName === "opencode" ? "verbose" : "standard",
+    lengthTruncationNotice: runtimeName !== "opencode",
+  }
+}
+
+/**
+ * สร้าง adapter ตาม config — `import` แบบ lazy เพื่อไม่ให้ต้องโหลด SDK
+ * ของ engine ที่ไม่ได้ใช้ (โดยเฉพาะ `claude` ที่ SDK เป็น optional peer)
+ */
+export async function createRuntime(
+  config: BotConfig,
+  env: Record<string, string | undefined>,
+): Promise<RuntimePort> {
+  switch (config.runtimeName) {
+    case "opencode": {
+      const { OpenCodeAdapter } = await import("@botforge/adapter-opencode")
+      return new OpenCodeAdapter({
+        url: env.OPENCODE_URL ?? "http://opencode:4096",
+        password: env.OPENCODE_PASSWORD,
+        directory: env.OPENCODE_DIR ?? config.workspaceDir,
+        promptTimeoutMs: config.promptTimeoutMs,
+      })
+    }
+    case "codex": {
+      const { CodexAdapter } = await import("@botforge/adapter-codex")
+      return new CodexAdapter({
+        command: env.CODEX_BIN ?? "codex",
+        args: ["app-server"],
+        model: env.CODEX_MODEL ?? "o4-mini",
+        workspaceDir: config.workspaceDir,
+        promptTimeoutMs: config.promptTimeoutMs,
+      })
+    }
+    case "claude": {
+      const { ClaudeAdapter } = await import("@botforge/adapter-claude")
+      return new ClaudeAdapter({
+        workspaceDir: config.workspaceDir,
+        model: env.CLAUDE_MODEL ?? "sonnet",
+        maxTurns: Number(env.CLAUDE_MAX_TURNS ?? 10),
+        maxBudgetUsd: Number(env.CLAUDE_MAX_BUDGET_USD ?? 1.0),
+        promptTimeoutMs: config.promptTimeoutMs,
+      })
+    }
+    case "adkcode": {
+      const { AdkcodeAdapter } = await import("@botforge/adapter-adkcode")
+      return new AdkcodeAdapter({
+        url: env.ADKCODE_URL ?? "http://server:8000",
+        auth: env.SERVER_PASSWORD ? `Bearer ${env.SERVER_PASSWORD}` : undefined,
+        promptTimeoutMs: config.promptTimeoutMs,
+      })
+    }
+  }
+}

--- a/apps/line-bot/src/main.ts
+++ b/apps/line-bot/src/main.ts
@@ -1,0 +1,65 @@
+/**
+ * LINE bot ที่ deploy ได้ — ชิ้นที่ทำให้ V2 ส่งมอบอะไรได้เป็นครั้งแรก
+ *
+ *   npm start --prefix apps/line-bot
+ *
+ * ประกอบ `@botforge/core` + `@botforge/channel-line` + adapter ตาม `BOTFORGE_RUNTIME`
+ * ไฟล์นี้ไม่มี logic ของ LINE หรือของ runtime อยู่เลย — เป็นแค่ตัวต่อสาย
+ */
+import { createLineChannel } from "@botforge/channel-line"
+import { EventEmitter, BotforgeEvents, type EventSink } from "@botforge/core/events"
+import { readConfig, createRuntime, ConfigError } from "./config.ts"
+
+const stamp = () => new Date().toISOString()
+const log = (...args: unknown[]) => console.log(`[${stamp()}]`, ...args)
+
+let config
+try {
+  config = readConfig(process.env)
+} catch (err) {
+  if (err instanceof ConfigError || (err as Error)?.name === "MissingScopeError") {
+    console.error(`✗ config ไม่ครบ: ${(err as Error).message}`)
+    process.exit(2)
+  }
+  throw err
+}
+
+/**
+ * sink ปลายทางของ audit event
+ *
+ * ตอนนี้เขียนลง stdout เป็น JSON บรรทัดละใบ — ยังไม่ได้ส่งเข้า ecosystem
+ * แต่ผลิตครบตาม `event/v1` แล้ว เปลี่ยนปลายทางทีหลังได้โดยไม่แตะที่อื่น
+ */
+const sink: EventSink = {
+  emit(event) { console.log(JSON.stringify(event)) },
+}
+
+const runtime = await createRuntime(config, process.env)
+const events = new BotforgeEvents(new EventEmitter(config.scope, { sink }))
+
+const channel = await createLineChannel({
+  runtime,
+  events,
+  channelSecret: config.channelSecret,
+  channelAccessToken: config.channelAccessToken,
+  port: config.port,
+  botName: config.botName,
+  lineOaUrl: config.lineOaUrl,
+  runtimeName: config.runtimeName,
+  userContextFormat: config.userContextFormat,
+  lengthTruncationNotice: config.lengthTruncationNotice,
+  log,
+})
+
+log(`พร้อมแล้ว`)
+log(`  runtime   : ${config.runtimeName}`)
+log(`  tenant    : ${config.scope.tenant_id} · workspace ${config.scope.workspace_id}`)
+log(`  webhook   : ${channel.url}/webhook`)
+log(`  bot userId: ${channel.botUserId || "(ดึงไม่ได้)"}`)
+
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    log(`ได้รับ ${sig} — กำลังปิด`)
+    void channel.close().then(() => process.exit(0))
+  })
+}

--- a/apps/line-bot/tsconfig.json
+++ b/apps/line-bot/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2024"
+    ],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/docs/architecture/open-items.md
+++ b/docs/architecture/open-items.md
@@ -4,6 +4,21 @@
 
 ---
 
+## ✅ ปิดแล้ว 2026-08-23 — V2 ส่งมอบได้แล้ว
+
+~~ช่องว่างที่ใหญ่ที่สุด~~ — [`packages/channel-line`](../../packages/channel-line/) +
+[`apps/line-bot`](../../apps/line-bot/) ปิดข้อนี้แล้ว
+
+```
+POST /webhook → 200 OK (67 ms)  ·  signature ผิด → 403
+audit event 3 ใบ · model จริงตอบ · reply→push fallback ทำงานจริงตอน 401
+```
+
+**เหลือขั้นสุดท้ายที่ยังไม่ได้ยืนยัน:** ส่งถึง LINE จริง (ต้องมี channel token ของจริง)
+และยังไม่มี `docker-compose.yml` · ไม่มี template ให้ `botforge new` · ไม่มีเส้นทางย้าย 14 bot
+
+<details><summary>บันทึกเดิมก่อนแก้</summary>
+
 ## 🔴 ช่องว่างที่ใหญ่ที่สุด — V2 ยังส่งมอบอะไรไม่ได้
 
 มี library ครบแล้ว **แต่ไม่มีอะไรประกอบเป็น bot ที่ deploy ได้**
@@ -22,6 +37,8 @@
 งานที่ทำมาทั้งหมดยังไม่ถึงมือผู้ใช้จริงสักคน
 
 > ถ้าจะทำต่ออย่างเดียว ควรเป็นอันนี้ — `channel-line` แล้วต่อด้วย `apps/line-bot`
+
+</details>
 
 ---
 
@@ -122,6 +139,6 @@ verify ราย field แล้วเฉพาะ `error/v1` · `event/v1` · `
 | 2 จัดโครง repo | ✅ โดยพฤตินัย — `packages/` แทนโครง `core/ agents/ sessions/` ที่ doc เดิมวางไว้ |
 | 3 RuntimeAdapter | 🚧 4/9 · ที่เหลือพักไว้ |
 | 4 Agent Platform runtime | ⬜ ยังไม่เริ่ม — `agent-backend-os` ยังไม่มี repo |
-| 5 Multi-channel | 🚧 web ✅ · **line ยังไม่มี** · telegram/discord ⬜ |
+| 5 Multi-channel | 🚧 web ✅ · line ✅ · telegram/discord ⬜ |
 
-> **Phase 5 ย้อนแย้ง** — เรามี channel ที่สองก่อนมี channel ที่หนึ่ง
+> **Phase 5 เคยย้อนแย้ง** — มี channel ที่สองก่อนมี channel ที่หนึ่ง · แก้แล้ว 2026-08-23

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "license": "MIT",
   "description": "Agent Bot Factory — V2 workspace",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
   "scripts": {
     "test": "npm test --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",

--- a/packages/channel-line/package.json
+++ b/packages/channel-line/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@botforge/channel-line",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "description": "LINE channel — webhook + Messaging API · channel ที่ 14 bot ใช้จริง",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": { "@botforge/core": "^0.0.1" },
+  "peerDependencies": { "@line/bot-sdk": ">=9" },
+  "peerDependenciesMeta": { "@line/bot-sdk": { "optional": true } },
+  "devDependencies": { "@types/node": "^22", "typescript": "^5.7.0" }
+}

--- a/packages/channel-line/src/api.ts
+++ b/packages/channel-line/src/api.ts
@@ -1,0 +1,40 @@
+/**
+ * port ของ LINE Messaging API
+ *
+ * ใช้ `@line/bot-sdk` เป็น **optional peer dependency** ไม่ได้เขียน REST เอง
+ * เหตุผล: endpoint ของ LINE ไม่ควรเดาจากความจำ · v1 ใช้ SDK นี้อยู่แล้วและทำงานได้จริง
+ * (รูปแบบเดียวกับ `adapter-claude` ที่ห่อ Claude Agent SDK)
+ *
+ * แยกเป็น port เพื่อให้ test ฉีด fake ได้ — ไม่ต้องมี SDK ไม่ต้องมี channel token
+ */
+
+export interface LineTextMessage { type: "text"; text: string }
+
+export interface LineApi {
+  replyMessage(args: { replyToken: string; messages: LineTextMessage[] }): Promise<unknown>
+  pushMessage(args: { to: string; messages: LineTextMessage[] }): Promise<unknown>
+  getProfile(userId: string): Promise<{ displayName?: string; pictureUrl?: string; statusMessage?: string }>
+  getGroupMemberProfile(groupId: string, userId: string): Promise<{ displayName?: string; pictureUrl?: string }>
+  getGroupSummary(groupId: string): Promise<{ groupName?: string }>
+  showLoadingAnimation(args: { chatId: string; loadingSeconds?: number }): Promise<unknown>
+  getBotInfo(): Promise<{ userId?: string; displayName?: string }>
+}
+
+/**
+ * สร้าง client จาก SDK จริง — import แบบ lazy ตอนเรียก
+ *
+ * v1 ใช้ `new line.messagingApi.MessagingApiClient({ channelAccessToken })`
+ */
+export async function createLineApi(channelAccessToken: string): Promise<LineApi> {
+  let mod: any
+  try {
+    const specifier = "@line/bot-sdk"
+    mod = await import(specifier)
+  } catch (err) {
+    throw new Error(
+      "ไม่พบ @line/bot-sdk — ติดตั้งด้วย `npm i @line/bot-sdk` หรือฉีด api เองผ่าน options.api\n" +
+        `สาเหตุเดิม: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+  return new mod.messagingApi.MessagingApiClient({ channelAccessToken }) as LineApi
+}

--- a/packages/channel-line/src/index.ts
+++ b/packages/channel-line/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./api.ts"
+export * from "./transport.ts"
+export * from "./messages.ts"
+export * from "./webhook.ts"
+export * from "./server.ts"

--- a/packages/channel-line/src/line.test.ts
+++ b/packages/channel-line/src/line.test.ts
@@ -1,0 +1,252 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { createHmac } from "node:crypto"
+import { createLineChannel } from "./server.ts"
+import { classify } from "./webhook.ts"
+import { welcomeMessage, NO_VISION_MESSAGE } from "./messages.ts"
+import { triggersFor } from "@botforge/core/channel"
+import type { LineApi } from "./api.ts"
+import type { RuntimePort, PromptInput, RuntimeResult } from "@botforge/core/router"
+import { EventEmitter, MemorySink, BotforgeEvents } from "@botforge/core/events"
+import { resolveScope } from "@botforge/core/identity"
+
+const SECRET = "test-channel-secret"
+const BOT_ID = "Ubot0000000000000000000000000001"
+const USER = "U4af4980629f1b2c3d4e5f6a7b8c9d0e1"
+const GROUP = "Ca56f9e2b1c3d4e5f6a7b8c9d0e1f2a3"
+
+function fakeApi() {
+  const calls: Array<{ m: string; args: unknown }> = []
+  const api: LineApi = {
+    async replyMessage(a) { calls.push({ m: "reply", args: a }); return {} },
+    async pushMessage(a) { calls.push({ m: "push", args: a }); return {} },
+    async getProfile() { return { displayName: "สมชาย" } },
+    async getGroupMemberProfile() { return { displayName: "สมชาย" } },
+    async getGroupSummary() { return { groupName: "ทีมกฎหมาย" } },
+    async showLoadingAnimation(a) { calls.push({ m: "loading", args: a }); return {} },
+    async getBotInfo() { return { userId: BOT_ID } },
+  }
+  return { api, calls, texts: () => calls.filter((c) => c.m !== "loading").map((c) => (c.args as any).messages[0].text) }
+}
+
+function fakeRuntime(reply: (i: PromptInput) => RuntimeResult | Promise<RuntimeResult> = () => ({ result: "ตอบครับ" })) {
+  const seen: PromptInput[] = []
+  const reset: string[] = []
+  const runtime = {
+    async sendPrompt(i: PromptInput) { seen.push(i); return reply(i) },
+    resetSession(k: string) { reset.push(k) },
+  } satisfies RuntimePort & { resetSession(k: string): void }
+  return { runtime, seen, reset }
+}
+
+const sign = (body: string) => createHmac("SHA256", SECRET).update(body).digest("base64")
+
+async function webhook(url: string, events: unknown[], badSignature = false) {
+  const body = JSON.stringify({ events })
+  return fetch(`${url}/webhook`, {
+    method: "POST",
+    // signature ต้องเป็น ASCII — HTTP header เป็น ByteString ใส่ภาษาไทยไม่ได้
+    headers: { "content-type": "application/json", "x-line-signature": badSignature ? "bm90LWEtc2lnbmF0dXJl" : sign(body) },
+    body,
+  })
+}
+
+const textEvent = (over: Record<string, unknown> = {}) => ({
+  type: "message", replyToken: "TOKEN",
+  message: { id: "m-1", type: "text", text: "สวัสดี" },
+  source: { type: "user", userId: USER },
+  ...over,
+})
+
+const settle = () => new Promise((r) => setTimeout(r, 80))
+
+test("webhook 1:1 → runtime → reply กลับ", async () => {
+  const { api, calls, texts } = fakeApi()
+  const { runtime, seen } = fakeRuntime()
+  const ch = await createLineChannel({ runtime, api, channelSecret: SECRET, host: "127.0.0.1" })
+  try {
+    assert.equal((await webhook(ch.url, [textEvent()])).status, 200)
+    await settle()
+    assert.equal(seen.length, 1)
+    assert.equal(seen[0]!.text, "สวัสดี")
+    assert.deepEqual(texts(), ["ตอบครับ"])
+    assert.equal(calls[0]!.m, "loading", "1:1 ต้องโชว์ loading ก่อน")
+  } finally { await ch.close() }
+})
+
+test("signature ผิด → 403 และไม่เรียก runtime", async () => {
+  const { api } = fakeApi()
+  const { runtime, seen } = fakeRuntime()
+  const ch = await createLineChannel({ runtime, api, channelSecret: SECRET, host: "127.0.0.1" })
+  try {
+    assert.equal((await webhook(ch.url, [textEvent()], true)).status, 403)
+    await settle()
+    assert.equal(seen.length, 0)
+  } finally { await ch.close() }
+})
+
+test("JSON พัง → 400", async () => {
+  const { api } = fakeApi()
+  const { runtime } = fakeRuntime()
+  const ch = await createLineChannel({ runtime, api, channelSecret: SECRET, host: "127.0.0.1" })
+  try {
+    const body = "{ พัง"
+    const res = await fetch(`${ch.url}/webhook`, {
+      method: "POST", headers: { "x-line-signature": sign(body) }, body,
+    })
+    assert.equal(res.status, 400)
+  } finally { await ch.close() }
+})
+
+test("ตอบ 200 ทันทีไม่รอ runtime — LINE จะได้ไม่ retry", async () => {
+  const { api } = fakeApi()
+  let release!: () => void
+  const gate = new Promise<void>((r) => { release = r })
+  const { runtime } = fakeRuntime(async () => { await gate; return { result: "ช้า" } })
+  const ch = await createLineChannel({ runtime, api, channelSecret: SECRET, host: "127.0.0.1" })
+  try {
+    const started = Date.now()
+    assert.equal((await webhook(ch.url, [textEvent()])).status, 200)
+    assert.ok(Date.now() - started < 500, "ต้องไม่รอ runtime")
+    release()
+  } finally { await ch.close() }
+})
+
+test("ในกลุ่ม: ไม่ได้เรียกถึง → ไม่ตอบ · เรียกถึง → ตอบ", async () => {
+  const { api, texts } = fakeApi()
+  const { runtime, seen } = fakeRuntime()
+  const ch = await createLineChannel({
+    runtime, api, channelSecret: SECRET, host: "127.0.0.1", runtimeName: "opencode",
+  })
+  try {
+    const group = { source: { type: "group", groupId: GROUP, userId: USER } }
+    await webhook(ch.url, [textEvent({ ...group, message: { id: "m", type: "text", text: "คุยกันเอง" } })])
+    await settle()
+    assert.equal(seen.length, 0, "ไม่ได้เรียกถึงต้องไม่ยิง runtime เลย")
+
+    await webhook(ch.url, [textEvent({ ...group, message: { id: "m", type: "text", text: "@bot ช่วยหน่อย" } })])
+    await settle()
+    assert.equal(seen.length, 1)
+    assert.equal(seen[0]!.isGroup, true)
+    assert.deepEqual(texts(), ["ตอบครับ"])
+  } finally { await ch.close() }
+})
+
+test("join → welcome เฉพาะ group · leave → เคลียร์ session ของ runtime", async () => {
+  const { api, texts } = fakeApi()
+  const { runtime, reset } = fakeRuntime()
+  const ch = await createLineChannel({
+    runtime, api, channelSecret: SECRET, host: "127.0.0.1",
+    botName: "OpenCode Bot", lineOaUrl: "https://line.me/ti/p/~x",
+  })
+  try {
+    await webhook(ch.url, [{ type: "join", source: { type: "group", groupId: GROUP } }])
+    await settle()
+    assert.equal(texts().length, 1)
+    assert.ok(texts()[0]!.includes("OpenCode Bot"))
+    assert.ok(texts()[0]!.includes("https://line.me/ti/p/~x"))
+
+    await webhook(ch.url, [{ type: "join", source: { type: "room", roomId: "R1" } }])
+    await settle()
+    assert.equal(texts().length, 1, "room ไม่ส่ง welcome — พฤติกรรมของ v1")
+
+    await webhook(ch.url, [{ type: "leave", source: { type: "group", groupId: GROUP } }])
+    await settle()
+    assert.deepEqual(reset, [GROUP])
+  } finally { await ch.close() }
+})
+
+test("รูปภาพ: 1:1 ตอบว่าดูไม่ได้ · ในกลุ่มเงียบ", async () => {
+  const { api, texts } = fakeApi()
+  const { runtime, seen } = fakeRuntime()
+  const ch = await createLineChannel({ runtime, api, channelSecret: SECRET, host: "127.0.0.1" })
+  try {
+    await webhook(ch.url, [textEvent({ message: { id: "i1", type: "image" } })])
+    await settle()
+    assert.deepEqual(texts(), [NO_VISION_MESSAGE])
+
+    await webhook(ch.url, [textEvent({
+      message: { id: "i2", type: "image" }, source: { type: "group", groupId: GROUP, userId: USER },
+    })])
+    await settle()
+    assert.equal(texts().length, 1, "ในกลุ่มต้องเงียบ")
+    assert.equal(seen.length, 0)
+  } finally { await ch.close() }
+})
+
+test("audit event ใช้ channel_type: line และ id ผ่าน toChannelId", async () => {
+  const { api } = fakeApi()
+  const { runtime } = fakeRuntime()
+  const sink = new MemorySink()
+  const scope = resolveScope({ BOTFORGE_TENANT_ID: "legal", BOTFORGE_WORKSPACE_ID: "legal-opencode" })
+  const ch = await createLineChannel({
+    runtime, api, channelSecret: SECRET, host: "127.0.0.1", runtimeName: "opencode",
+    events: new BotforgeEvents(new EventEmitter(scope, { sink })),
+  })
+  try {
+    await webhook(ch.url, [textEvent()])
+    await settle()
+    assert.deepEqual(sink.events.map((e) => e.event_type),
+      ["STATE_TRANSITION", "EXECUTION_STARTED", "STATE_TRANSITION"])
+    const e = sink.events[0]!
+    assert.equal(e.channel_type, "line")
+    assert.equal(e.channel_id, "line-u4af4980629f1b2c3d4e5f6a7b8c9d0e1")
+    assert.equal(e.actor!.id, "line-u4af4980629f1b2c3d4e5f6a7b8c9d0e1")
+    assert.equal(e.tenant_id, "legal")
+  } finally { await ch.close() }
+})
+
+test("health และ root", async () => {
+  const { api } = fakeApi()
+  const { runtime } = fakeRuntime()
+  const ch = await createLineChannel({ runtime, api, channelSecret: SECRET, host: "127.0.0.1", botName: "ทดสอบ" })
+  try {
+    assert.deepEqual(await (await fetch(`${ch.url}/health`)).json(), { ok: true, botUserId: BOT_ID })
+    assert.ok((await (await fetch(ch.url)).text()).includes("ทดสอบ"))
+    assert.equal((await fetch(`${ch.url}/ไม่มี`)).status, 404)
+    assert.equal(ch.botUserId, BOT_ID, "ดึง botUserId ตอน startup — feature 9.8")
+  } finally { await ch.close() }
+})
+
+// ── classify (ไม่ต้องมี HTTP) ──
+
+const mention = { botUserId: BOT_ID, triggers: triggersFor("claude") }
+
+test("classify — ครบทุกเส้นทาง", () => {
+  assert.equal(classify({ type: "join", source: { groupId: GROUP } }, { mention }).kind, "join")
+  assert.equal(classify({ type: "leave", source: { roomId: "R1" } }, { mention }).kind, "leave")
+  assert.equal(classify({ type: "follow", source: { userId: USER } }, { mention }).kind, "ignore")
+  assert.equal(classify({ type: "message", message: { type: "sticker" }, source: { userId: USER } }, { mention }).kind, "ignore")
+  assert.equal(classify({ type: "message", message: { type: "text", text: "   " }, source: { userId: USER } }, { mention }).kind, "ignore")
+  assert.equal(classify({ type: "message", message: { type: "text", text: "hi" }, source: {} }, { mention }).kind, "ignore")
+})
+
+test("classify — trim ข้อความตาม feature 9.6", () => {
+  const d = classify({ type: "message", message: { type: "text", text: "  สวัสดี  " }, source: { userId: USER } }, { mention })
+  assert.equal(d.kind === "text" && d.text, "สวัสดี")
+})
+
+test("classify — group ใช้ groupId เป็น sessionKey ทุกคนแชร์ session เดียว", () => {
+  const d = classify({
+    type: "message", message: { type: "text", text: "/help" },
+    source: { groupId: GROUP, userId: USER },
+  }, { mention })
+  assert.equal(d.kind === "text" && d.sessionKey, GROUP)
+  assert.equal(d.kind === "text" && d.userId, USER)
+})
+
+test("classify — LINE mention API ทำให้ตอบในกลุ่มได้แม้ไม่พิมพ์ trigger", () => {
+  const d = classify({
+    type: "message",
+    message: { type: "text", text: "ช่วยดูให้หน่อย", mention: { mentionees: [{ type: "user", userId: BOT_ID }] } } as any,
+    source: { groupId: GROUP, userId: USER },
+  }, { mention })
+  assert.equal(d.kind, "text")
+})
+
+test("welcomeMessage ยกมาจาก v1 ทุกตัวอักษร", () => {
+  const m = welcomeMessage({ botName: "OpenCode Bot", lineOaUrl: "https://x" })
+  assert.ok(m.startsWith("🧑‍💻 สวัสดีครับ! ผม OpenCode Bot"))
+  assert.ok(m.includes("📖 พิมพ์ /help ดูคำสั่งทั้งหมด"))
+  assert.ok(m.includes("🔒 คุยส่วนตัว: https://x"))
+})

--- a/packages/channel-line/src/messages.ts
+++ b/packages/channel-line/src/messages.ts
@@ -1,0 +1,22 @@
+/**
+ * ข้อความที่ bot ส่งเอง — ยกมาจาก v1-final ทุกตัวอักษร
+ *
+ * `{{...}}` ของ template ถูกแทนด้วย option ตอน runtime แทนที่จะแทนตอน generate
+ * — เป็นความต่างเชิงโครงสร้างจาก v1 ที่ใช้ placeholder ในไฟล์
+ */
+export interface WelcomeOptions {
+  botName: string
+  lineOaUrl: string
+}
+
+/** ส่งตอน bot ถูกเชิญเข้ากลุ่ม — v1 ส่งเฉพาะ group ไม่ส่ง room */
+export function welcomeMessage(o: WelcomeOptions): string {
+  return `🧑‍💻 สวัสดีครับ! ผม ${o.botName}
+
+💬 พิมพ์อะไรก็ได้ ผมช่วยได้ครับ
+📖 พิมพ์ /help ดูคำสั่งทั้งหมด
+🔒 คุยส่วนตัว: ${o.lineOaUrl}`
+}
+
+/** model ยังไม่มี vision — v1 ตอบเฉพาะ 1:1 ส่วนในกลุ่มเงียบ */
+export const NO_VISION_MESSAGE = "ยังดูรูปไม่ได้ครับ ส่งเป็นข้อความแทนนะ"

--- a/packages/channel-line/src/server.ts
+++ b/packages/channel-line/src/server.ts
@@ -1,0 +1,221 @@
+/**
+ * LINE channel — webhook server
+ *
+ * **channel ที่ 14 bot ใช้จริง** และเป็นชิ้นที่หายไปจาก V2 มาตลอด
+ * (`channel-web` มี server เต็มตัวตั้งแต่แรก ส่วน LINE มีแค่ primitive ใน core)
+ *
+ * ไฟล์นี้ไม่ import adapter ตัวไหนเลย — ผู้เรียกส่ง `runtime` เข้ามา
+ */
+import { createServer, type Server, type ServerResponse } from "node:http"
+import type { AddressInfo } from "node:net"
+import { runTurn, type RuntimePort, type TurnDeps } from "@botforge/core/router"
+import { SessionQueue } from "@botforge/core/session"
+import { ProfileCache, type UserContextFormat } from "@botforge/core/context"
+import { validateSignature, timingSafeValidateSignature, triggersFor } from "@botforge/core/channel"
+import { toChannelId } from "@botforge/core/identity"
+import type { BotforgeEvents, TurnContext } from "@botforge/core/events"
+import { createLineApi, type LineApi } from "./api.ts"
+import { LineTransport, lineProfileSource } from "./transport.ts"
+import { classify, type LineWebhookEvent } from "./webhook.ts"
+import { welcomeMessage, NO_VISION_MESSAGE } from "./messages.ts"
+
+export interface LineChannelOptions {
+  runtime: RuntimePort
+  channelSecret: string
+  /** ไม่ส่ง `api` มาก็ต้องมีอันนี้ */
+  channelAccessToken?: string
+  /** ฉีด LINE API เองได้ — ใช้ตอน test */
+  api?: LineApi
+  port?: number
+  host?: string
+  botName?: string
+  lineOaUrl?: string
+  /** คำที่ถือว่าเรียก bot ในกลุ่ม — ค่าเริ่มต้นมาจากชื่อ runtime */
+  mentionTriggers?: string[]
+  events?: BotforgeEvents
+  runtimeName?: string
+  userContextFormat?: UserContextFormat
+  lengthTruncationNotice?: boolean
+  /** เทียบ signature แบบ constant-time — v1 ใช้ `===` · ค่าเริ่มต้นคือของ v1 */
+  timingSafeSignature?: boolean
+  log?: (...args: unknown[]) => void
+}
+
+export interface LineChannel {
+  server: Server
+  url: string
+  api: LineApi
+  /** userId ของ bot จาก `getBotInfo()` — ใช้กับ LINE mention API (feature 9.8) */
+  botUserId: string
+  close(): Promise<void>
+}
+
+export async function createLineChannel(options: LineChannelOptions): Promise<LineChannel> {
+  const log = options.log ?? (() => {})
+  const api = options.api ?? (await createLineApi(requireToken(options)))
+
+  // v1 ดึง botUserId ตอน startup เพื่อให้ mention detection ใช้ LINE mention API ได้
+  let botUserId = ""
+  try {
+    botUserId = (await api.getBotInfo())?.userId ?? ""
+    log("bot userId:", botUserId)
+  } catch (err) {
+    log("ดึง bot info ไม่ได้:", err instanceof Error ? err.message : err)
+  }
+
+  const transport = new LineTransport(api)
+  const profiles = new ProfileCache(lineProfileSource(api), { warn: log })
+  const verify = options.timingSafeSignature ? timingSafeValidateSignature : validateSignature
+  const mention = {
+    botUserId,
+    triggers: options.mentionTriggers ?? triggersFor(options.runtimeName ?? "bot"),
+  }
+
+  const deps: TurnDeps = {
+    runtime: options.runtime,
+    transport,
+    queue: new SessionQueue(),
+    profiles,
+    ...(options.events ? { events: options.events } : {}),
+    ...(options.userContextFormat ? { userContextFormat: options.userContextFormat } : {}),
+    ...(options.lengthTruncationNotice === false ? { lengthTruncationNotice: false } : {}),
+    showLoading: (chatId) => {
+      // fire-and-forget เหมือน v1 — ล้มก็ไม่กระทบการตอบ
+      void api.showLoadingAnimation({ chatId, loadingSeconds: 60 }).catch(() => {})
+    },
+    log,
+  }
+
+  let turnSeq = 0
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost")
+
+    if (req.method === "GET" && url.pathname === "/") {
+      return text(res, 200, `${options.botName ?? "Botforge"} LINE Bot is running`)
+    }
+    if (req.method === "GET" && url.pathname === "/health") {
+      return json(res, 200, { ok: true, botUserId })
+    }
+    if (req.method !== "POST" || url.pathname !== "/webhook") {
+      return text(res, 404, "Not Found")
+    }
+
+    let body = ""
+    req.on("data", (c) => { body += c })
+    req.on("end", () => {
+      const signature = String(req.headers["x-line-signature"] ?? "")
+      if (!verify(body, signature, options.channelSecret)) {
+        log("signature ไม่ถูกต้อง")
+        return text(res, 403, "Invalid signature")
+      }
+      let parsed: { events?: LineWebhookEvent[] }
+      try {
+        parsed = JSON.parse(body)
+      } catch {
+        return text(res, 400, "Invalid JSON")
+      }
+      // ตอบ 200 ทันทีเพื่อไม่ให้ LINE retry — งานจริงทำต่อเบื้องหลัง (พฤติกรรมของ v1)
+      text(res, 200, "OK")
+      for (const event of parsed.events ?? []) {
+        void handle(event).catch((err) => log("จัดการ event ไม่สำเร็จ:", err))
+      }
+    })
+  })
+
+  async function handle(event: LineWebhookEvent): Promise<void> {
+    const decision = classify(event, { mention })
+
+    switch (decision.kind) {
+      case "ignore":
+        log("ข้าม:", decision.reason)
+        return
+
+      case "join": {
+        if (!decision.groupId) return   // v1 ส่ง welcome เฉพาะ group ไม่ส่ง room
+        const msg = welcomeMessage({
+          botName: options.botName ?? "Botforge Bot",
+          lineOaUrl: options.lineOaUrl ?? "",
+        })
+        await api.pushMessage({ to: decision.groupId, messages: [{ type: "text", text: msg }] })
+          .catch((err) => log("ส่ง welcome ไม่สำเร็จ:", err?.message ?? err))
+        await options.events?.channelJoined("line", toChannelId("line", decision.chatId))
+        return
+      }
+
+      case "leave": {
+        await resetRuntimeSession(decision.chatId)
+        await options.events?.channelLeft("line", toChannelId("line", decision.chatId))
+        return
+      }
+
+      case "image": {
+        if (decision.isGroup) return    // ในกลุ่มเงียบ — v1 ทำแบบนี้
+        if (decision.replyToken) {
+          await transport.reply(decision.replyToken, NO_VISION_MESSAGE).catch(() => {})
+        }
+        return
+      }
+
+      case "text": {
+        const ctx: TurnContext | undefined = options.events
+          ? {
+              executionId: `line-exec-${++turnSeq}`,
+              channelId: toChannelId("line", decision.sessionKey),
+              channelType: "line",
+              actor: { type: "human", id: toChannelId("line", decision.userId) },
+              ...(event.message?.id ? { messageId: event.message.id } : {}),
+            }
+          : undefined
+
+        await runTurn(deps, {
+          sessionKey: decision.sessionKey,
+          userId: decision.userId,
+          text: decision.text,
+          isGroup: decision.isGroup,
+          ...(decision.replyToken ? { replyToken: decision.replyToken } : {}),
+          ...(decision.groupId ? { groupId: decision.groupId } : {}),
+          ...(decision.quotedMessageId ? { quotedMessageId: decision.quotedMessageId } : {}),
+          ...(ctx ? { ctx } : {}),
+          ...(options.runtimeName ? { runtimeName: options.runtimeName } : {}),
+        })
+        return
+      }
+    }
+  }
+
+  /** adapter แต่ละตัวตั้งชื่อเมธอดต่างกัน — เรียกเท่าที่มี ไม่บังคับให้ทุกตัวต้องมี */
+  async function resetRuntimeSession(sessionKey: string): Promise<void> {
+    const r = options.runtime as { resetSession?: (k: string) => unknown }
+    if (typeof r.resetSession === "function") {
+      await Promise.resolve(r.resetSession(sessionKey)).catch(() => {})
+    }
+  }
+
+  return new Promise((resolve) => {
+    server.listen(options.port ?? 0, options.host ?? "0.0.0.0", () => {
+      const addr = server.address() as AddressInfo
+      resolve({
+        server, api, botUserId,
+        url: `http://${options.host ?? "0.0.0.0"}:${addr.port}`,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      })
+    })
+  })
+}
+
+function requireToken(o: LineChannelOptions): string {
+  if (!o.channelAccessToken) {
+    throw new Error("ต้องมี channelAccessToken หรือส่ง api เข้ามาเอง")
+  }
+  return o.channelAccessToken
+}
+
+function text(res: ServerResponse, status: number, body: string): void {
+  res.writeHead(status, { "content-type": "text/plain; charset=utf-8" })
+  res.end(body)
+}
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" })
+  res.end(JSON.stringify(body))
+}

--- a/packages/channel-line/src/transport.ts
+++ b/packages/channel-line/src/transport.ts
@@ -1,0 +1,31 @@
+/**
+ * ChannelTransport ของ LINE
+ *
+ * `reply` ใช้ replyToken ซึ่ง **ฟรีและใช้ได้ครั้งเดียว** · `push` กินโควตา
+ * `sendMessage()` ของ core ลอง reply ก่อนแล้ว fallback เป็น push อยู่แล้ว
+ * — นี่คือเหตุผลที่ `ChannelTransport` ออกแบบให้มีสองเมธอด
+ */
+import type { ChannelTransport } from "@botforge/core/channel"
+import type { LineApi } from "./api.ts"
+
+export class LineTransport implements ChannelTransport {
+  readonly #api: LineApi
+  constructor(api: LineApi) { this.#api = api }
+
+  async reply(replyToken: string, text: string): Promise<void> {
+    await this.#api.replyMessage({ replyToken, messages: [{ type: "text", text }] })
+  }
+
+  async push(to: string, text: string): Promise<void> {
+    await this.#api.pushMessage({ to, messages: [{ type: "text", text }] })
+  }
+}
+
+/** `LineProfileSource` ของ core ต่อกับ Messaging API ตรง ๆ */
+export function lineProfileSource(api: LineApi) {
+  return {
+    getProfile: (userId: string) => api.getProfile(userId),
+    getGroupMemberProfile: (groupId: string, userId: string) => api.getGroupMemberProfile(groupId, userId),
+    getGroupSummary: (groupId: string) => api.getGroupSummary(groupId),
+  }
+}

--- a/packages/channel-line/src/webhook.ts
+++ b/packages/channel-line/src/webhook.ts
@@ -1,0 +1,74 @@
+/**
+ * แปลง webhook payload ของ LINE เป็นสิ่งที่ core เข้าใจ
+ *
+ * แยกออกจาก server เพราะ **ตรรกะการตัดสินใจทั้งหมดอยู่ตรงนี้** และทดสอบได้โดยไม่ต้องมี HTTP
+ * ส่วน server เหลือแค่ verify signature · ตอบ 200 · แล้วส่งต่อมาที่นี่
+ */
+import { getSessionKey, isBotMentioned, type LineEventLike, type MentionConfig } from "@botforge/core/channel"
+
+export type LineWebhookEvent = LineEventLike & {
+  type?: string
+  replyToken?: string
+  message?: { id?: string; type?: string; text?: string; quotedMessageId?: string }
+  source?: { type?: string; groupId?: string; roomId?: string; userId?: string }
+}
+
+export type Decision =
+  | { kind: "text"; sessionKey: string; userId: string; text: string; replyToken?: string; isGroup: boolean; groupId?: string; quotedMessageId?: string }
+  | { kind: "image"; sessionKey: string; userId: string; replyToken?: string; isGroup: boolean }
+  | { kind: "join"; chatId: string; groupId?: string }
+  | { kind: "leave"; chatId: string }
+  | { kind: "ignore"; reason: string }
+
+export interface ClassifyOptions {
+  mention: MentionConfig
+}
+
+/**
+ * ลำดับการตัดสินใจ ยกมาจาก v1:
+ *   join / leave    จัดการก่อน ไม่ต้องมี session
+ *   message.text    ในกลุ่มต้องถูกเรียกถึงก่อน (`isBotMentioned`) · 1:1 ตอบทุกข้อความ
+ *   message.image   ตอบเฉพาะ 1:1 · ในกลุ่มเงียบ
+ *   อื่น ๆ           ข้าม
+ *
+ * ⚠️ `text.trim()` ทำที่นี่ ตรงกับ feature 9.6 ของ v1
+ */
+export function classify(event: LineWebhookEvent, options: ClassifyOptions): Decision {
+  const source = event.source ?? {}
+  const isGroup = Boolean(source.groupId || source.roomId)
+  const chatId = source.groupId || source.roomId
+
+  if (event.type === "join") {
+    if (!chatId) return { kind: "ignore", reason: "join ที่ไม่มี group/room" }
+    return { kind: "join", chatId, ...(source.groupId ? { groupId: source.groupId } : {}) }
+  }
+  if (event.type === "leave") {
+    if (!chatId) return { kind: "ignore", reason: "leave ที่ไม่มี group/room" }
+    return { kind: "leave", chatId }
+  }
+  if (event.type !== "message") return { kind: "ignore", reason: `event ชนิด ${event.type}` }
+
+  const sessionKey = getSessionKey(event)
+  const userId = source.userId
+  if (!sessionKey || !userId) return { kind: "ignore", reason: "ไม่มี sessionKey หรือ userId" }
+
+  if (event.message?.type === "image") {
+    return { kind: "image", sessionKey, userId, isGroup, ...(event.replyToken ? { replyToken: event.replyToken } : {}) }
+  }
+  if (event.message?.type !== "text") return { kind: "ignore", reason: `message ชนิด ${event.message?.type}` }
+
+  const text = (event.message.text ?? "").trim()
+  if (!text) return { kind: "ignore", reason: "ข้อความว่าง" }
+
+  // ในกลุ่ม ตอบเฉพาะตอนถูกเรียกถึง — 1:1 ตอบทุกข้อความ
+  if (isGroup && !isBotMentioned(event, options.mention)) {
+    return { kind: "ignore", reason: "ในกลุ่มแต่ไม่ได้เรียกถึง bot" }
+  }
+
+  return {
+    kind: "text", sessionKey, userId, text, isGroup,
+    ...(event.replyToken ? { replyToken: event.replyToken } : {}),
+    ...(source.groupId ? { groupId: source.groupId } : {}),
+    ...(event.message.quotedMessageId ? { quotedMessageId: event.message.quotedMessageId } : {}),
+  }
+}

--- a/packages/channel-line/tsconfig.json
+++ b/packages/channel-line/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2024"
+    ],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## ปิดช่องว่างที่ใหญ่ที่สุดใน [`open-items.md`](../blob/v2/docs/architecture/open-items.md)

เดิม V2 มี library ครบแต่ **ไม่มีอะไรประกอบเป็น service** · `channel-web` มี HTTP server เต็มตัวตั้งแต่แรก ส่วน **LINE ซึ่งเป็น channel ของทั้ง 14 bot มีแค่ primitive**

## ยืนยันแล้วกับ model จริง

สตาร์ท `apps/line-bot` ต่อ OpenCode server แล้วยิง webhook ที่เซ็นถูกต้อง:

```
POST /webhook → 200 OK (67 ms — ตอบทันทีไม่รอ model)
signature ผิด → 403 Invalid signature

audit event (event/v1)
   1 STATE_TRANSITION   pending→queued     tenant=legal channel=line
   2 EXECUTION_STARTED                     tenant=legal channel=line
   3 STATE_TRANSITION   running→succeeded  tenant=legal channel=line
```

> ใช้ LINE token ปลอม การส่งกลับจึงได้ 401 แล้ว **fallback `reply`→`push` ทำงานจริง** — ก่อนหน้านี้พิสูจน์ได้แค่ใน test
>
> **ขั้นสุดท้ายที่ยังไม่ได้ยืนยันคือส่งถึง LINE จริง** ต้องมี channel token ของจริง

## `packages/channel-line`

| | |
| --- | --- |
| `api.ts` | port ของ Messaging API — ใช้ `@line/bot-sdk` เป็น **optional peer ไม่เขียน REST เอง** เพราะ endpoint ไม่ควรเดาจากความจำ และ docs site ดึงผ่าน WebFetch ไม่ได้ |
| `webhook.ts` | `classify()` แยกตรรกะการตัดสินใจออกจาก HTTP — ทดสอบได้โดยไม่ต้องมี server |
| `server.ts` | verify signature → **ตอบ 200 ทันที** → ทำงานเบื้องหลัง · ดึง `botUserId` ตอน startup (feature 9.8) |
| `messages.ts` | welcome + no-vision ยกมาจาก v1 ทุกตัวอักษร |

## `apps/line-bot`

เลือก runtime ด้วย env ตัวเดียว: `BOTFORGE_RUNTIME=opencode|codex|claude|adkcode`

`main.ts` **ไม่มี logic ของ LINE หรือ runtime เลย** — เป็นแค่ตัวต่อสาย · `config.ts` เป็นจุดเดียวที่รู้ว่า adapter ไหนต้องการ env อะไร (`import` แบบ lazy)

ขาด `BOTFORGE_TENANT_ID`/`WORKSPACE_ID` → **exit 2** ไม่สตาร์ทแล้วปล่อย event ที่ผิด (`event/v1` ห้ามเดา tenant)

Dockerfile รัน TypeScript ตรง ๆ ด้วย `--experimental-strip-types` — **ไม่มี build step**

## ยังไม่ได้ทำ

ส่งถึง LINE จริง · `docker-compose.yml` (v1 มี 3 container) · template ให้ `botforge new` · เส้นทางย้าย 14 bot

---

**244 test** · Phase 5 ไม่ย้อนแย้งแล้ว — มี channel ที่หนึ่งครบ
