### PR TITLE
feat(line-bot): docker-compose ไฟล์เดียวรองรับทุก runtime ผ่าน profiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+**/node_modules
+.git
+templates
+projects
+models
+docs
+ref
+conformance/vendor
+scripts/scenarios
+**/*.test.ts
+**/fixtures
+.env
+**/.env

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ workspace-cowork-opencode/
 # npm lockfile ของ package ภายใน — ยังไม่ตัดสินว่าจะ commit หรือไม่
 packages/*/package-lock.json
 package-lock.json
+
+# workspace ที่ mount เข้า container ตอนรัน
+apps/*/workspace/
+docker-compose.override.yml

--- a/apps/line-bot/README.md
+++ b/apps/line-bot/README.md
@@ -12,6 +12,33 @@ cp apps/line-bot/.env.example apps/line-bot/.env   # แล้วเติมค
 npm start --prefix apps/line-bot
 ```
 
+### docker compose (แนะนำ)
+
+**ไฟล์เดียวรองรับทุก runtime** ผ่าน compose profiles — v1 มี `docker-compose.yml` แยกต่อ engine
+เพราะแต่ละ engine เป็นคนละ template
+
+```bash
+# จาก root ของ repo
+COMPOSE_PROFILES=opencode,tunnel docker compose -f apps/line-bot/docker-compose.yml up -d --build
+COMPOSE_PROFILES=claude          docker compose -f apps/line-bot/docker-compose.yml up -d --build
+```
+
+| profile | service ที่ขึ้น |
+| --- | --- |
+| `opencode` | `line-bot` + `opencode` |
+| `adkcode` | `line-bot` + `adkcode` |
+| `claude` / ไม่ใส่ | `line-bot` อย่างเดียว |
+| `+ tunnel` | เพิ่ม `cloudflared` |
+
+**`codex` และ `claude` ไม่ต้องมี container ของ engine** — `codex` spawn `app-server` เป็น
+child process ส่วน `claude` เรียก SDK ใน process เดียวกับ bot
+
+ของที่ต้อง mount จาก host (credential, `opencode.json`) ใส่ใน `docker-compose.override.yml`
+— ดู [`docker-compose.override.yml.example`](docker-compose.override.yml.example)
+**ไม่ใส่ในไฟล์หลักเพราะ compose ไม่มีวิธีทำ mount แบบ optional ที่ไม่เปราะ**
+
+### docker แบบไม่ใช้ compose
+
 ```bash
 docker build -f apps/line-bot/Dockerfile -t botforge-line-bot .
 docker run --env-file apps/line-bot/.env -p 3000:3000 botforge-line-bot
@@ -55,6 +82,24 @@ audit event (event/v1)
 > ทดสอบด้วย LINE token ปลอม การส่งกลับจึงได้ 401 แล้ว **fallback จาก `reply` ไป `push` ทำงานจริง**
 > ซึ่งก่อนหน้านี้พิสูจน์ได้แค่ใน test · ขั้นสุดท้ายที่ยังไม่ได้ยืนยันคือส่งถึง LINE จริง ต้องมี token ของจริง
 
+## ยืนยัน compose แล้ว
+
+`COMPOSE_PROFILES=opencode` build + up จริง แล้วยิง webhook จากในเครือข่าย compose:
+
+```
+line-bot  Up (healthy)      ← healthcheck ทำงาน
+opencode  Up
+
+POST /webhook -> 200 OK (78 ms)
+   1 STATE_TRANSITION   pending→queued     channel=line
+   2 EXECUTION_STARTED                     channel=line
+   3 STATE_TRANSITION   running→succeeded  channel=line
+```
+
+**bot container คุยกับ opencode container ผ่าน service name ได้จริง** และ model จริงตอบ
+
+`line-bot` **ไม่ publish port** เหมือน v1 — เข้าจากภายนอกผ่าน `cloudflared` เท่านั้น
+
 ## audit event
 
 เขียนลง **stdout เป็น JSON บรรทัดละใบ** ตาม `event/v1`
@@ -70,6 +115,5 @@ audit event (event/v1)
 ## ยังไม่ได้ทำ
 
 - ยังไม่ได้ยิงกับ LINE channel จริง — ต้องมี channel secret/token ของจริง
-- ไม่มี `docker-compose.yml` — v1 มี 3 container (bot + server + tunnel) · ตัวนี้ยังเป็น container เดียว
 - `botforge new` ยังสร้าง project แบบ V2 ไม่ได้ — ยังไม่มี template ที่ใช้ `packages/`
 - ยังไม่มีเส้นทางย้าย 14 bot จาก V1 มา V2

--- a/apps/line-bot/docker-compose.override.yml.example
+++ b/apps/line-bot/docker-compose.override.yml.example
@@ -1,0 +1,22 @@
+# คัดลอกเป็น docker-compose.override.yml แล้วแก้ตามเครื่อง
+# compose อ่านไฟล์ override อัตโนมัติเมื่ออยู่โฟลเดอร์เดียวกับ docker-compose.yml
+#
+# ใส่เฉพาะ service ที่ต้องการ mount เพิ่ม — ส่วนที่ไม่เขียนถึงใช้ค่าจากไฟล์หลัก
+
+services:
+  line-bot:
+    volumes:
+      # claude — ใช้ OAuth จาก host แทน ANTHROPIC_API_KEY
+      - ${HOME}/.claude:/root/.claude
+      # codex — ใช้ ChatGPT login จาก host
+      - ${HOME}/.codex:/root/.codex
+
+  opencode:
+    volumes:
+      # ทับ provider config ของ opencode (Thai LLM, OKMD ฯลฯ)
+      - ../../templates/bot-service-opencode/opencode.json:/root/.config/opencode/opencode.json:ro
+
+  adkcode:
+    volumes:
+      # Google ADC
+      - ${HOME}/.config/gcloud:/root/.config/gcloud:ro

--- a/apps/line-bot/docker-compose.yml
+++ b/apps/line-bot/docker-compose.yml
@@ -1,0 +1,95 @@
+# Botforge V2 — LINE bot
+#
+# ต่างจาก v1 ตรงที่ **ไฟล์เดียวรองรับทุก runtime** ผ่าน compose profiles
+# v1 มี docker-compose.yml แยกต่อ engine เพราะแต่ละ engine เป็นคนละ template
+#
+#   opencode / adkcode  ต้องมี container ของ engine แยก
+#   codex / claude      ไม่ต้องมี — codex spawn app-server เป็น child process
+#                       ส่วน claude เรียก SDK ใน process เดียวกับ bot
+#
+# รัน (จาก root ของ repo):
+#   COMPOSE_PROFILES=opencode,tunnel docker compose -f apps/line-bot/docker-compose.yml up -d --build
+#   COMPOSE_PROFILES=claude          docker compose -f apps/line-bot/docker-compose.yml up -d --build
+#
+# ตั้งค่าใน apps/line-bot/.env (ดู .env.example)
+# ของที่ต้อง mount จาก host เช่น credential หรือ opencode.json
+# ใส่ใน docker-compose.override.yml (ดู docker-compose.override.yml.example)
+# — ไม่ใส่ในไฟล์นี้เพราะ compose ไม่มีวิธีทำ mount แบบ optional ที่ไม่เปราะ
+
+name: ${CONTAINER_PREFIX:-botforge}
+
+services:
+  line-bot:
+    build:
+      context: ../..                      # ต้องเห็น packages/ ทั้งหมด
+      dockerfile: apps/line-bot/Dockerfile
+    container_name: ${CONTAINER_PREFIX:-botforge}-line-bot
+    env_file: [.env]
+    environment:
+      - PORT=3000
+      - WORKSPACE_DIR=/workspace
+      # ชี้ไปที่ service ใน network เดียวกัน — ทับค่าใน .env ที่เขียนไว้สำหรับรันนอก docker
+      - OPENCODE_URL=${OPENCODE_URL:-http://opencode:4096}
+      - ADKCODE_URL=${ADKCODE_URL:-http://adkcode:8000}
+    volumes:
+      - ${PROJECT_DIR:-./workspace}:/workspace
+      # credential ของ host (~/.claude, ~/.codex, ~/.config/gcloud) mount ผ่าน
+      # docker-compose.override.yml — ดู docker-compose.override.yml.example
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  # ── engine ที่ต้องมี container แยก ─────────────────────────────────
+
+  opencode:
+    profiles: [opencode]
+    image: ${OPENCODE_IMAGE:-ghcr.io/anomalyco/opencode:latest}
+    container_name: ${CONTAINER_PREFIX:-botforge}-opencode
+    command: ["serve", "--hostname=0.0.0.0", "--port=4096"]
+    working_dir: /workspace
+    environment:
+      - OPENCODE_SERVER_PASSWORD=${OPENCODE_PASSWORD:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - QWEN_API_KEY=${QWEN_API_KEY:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - OKMD_API_KEY=${OKMD_API_KEY:-}
+      - THAILLM_API_KEY=${THAILLM_API_KEY:-}
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+    volumes:
+      - ${PROJECT_DIR:-./workspace}:/workspace
+      - opencode-data:/root/.local/share/opencode
+      - opencode-state:/root/.local/state/opencode
+    restart: unless-stopped
+
+  adkcode:
+    profiles: [adkcode]
+    build:
+      context: ${ADKCODE_CONTEXT:-../../templates/bot-service-adkcode/server}
+    container_name: ${CONTAINER_PREFIX:-botforge}-adkcode
+    environment:
+      - API_PASSWORD=${SERVER_PASSWORD:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - GOOGLE_GENAI_USE_VERTEXAI=${GOOGLE_GENAI_USE_VERTEXAI:-}
+    volumes:
+      - ${PROJECT_DIR:-./workspace}:/workspace
+    restart: unless-stopped
+
+  # ── ทางเข้าจากอินเทอร์เน็ต ────────────────────────────────────────
+
+  cloudflared:
+    profiles: [tunnel]
+    image: cloudflare/cloudflared:latest
+    container_name: ${CONTAINER_PREFIX:-botforge}-tunnel
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on: [line-bot]
+    restart: unless-stopped
+
+volumes:
+  opencode-data:
+  opencode-state:


### PR DESCRIPTION
**ไฟล์เดียวรองรับทุก runtime** ผ่าน compose profiles — v1 มี `docker-compose.yml` แยกต่อ engine เพราะแต่ละ engine เป็นคนละ template

| profile | service ที่ขึ้น |
| --- | --- |
| `opencode` | `line-bot` + `opencode` |
| `adkcode` | `line-bot` + `adkcode` |
| `claude` / ไม่ใส่ | `line-bot` อย่างเดียว |
| `+ tunnel` | เพิ่ม `cloudflared` |

**`codex` และ `claude` ไม่ต้องมี container ของ engine** — `codex` spawn `app-server` เป็น child process · `claude` เรียก SDK ใน process เดียวกับ bot

## ยืนยันแล้วจริง ไม่ใช่แค่ validate

```
line-bot  Up (healthy)     ← healthcheck ทำงาน
opencode  Up

POST /webhook -> 200 OK (78 ms)
   1 STATE_TRANSITION   pending→queued     channel=line
   2 EXECUTION_STARTED                     channel=line
   3 STATE_TRANSITION   running→succeeded  channel=line
```

**bot container คุยกับ opencode container ผ่าน service name ได้จริง และ model จริงตอบ**

`line-bot` **ไม่ publish port** เหมือน v1 — เข้าจากภายนอกผ่าน `cloudflared` เท่านั้น

## เอา mount ที่เปราะออก

รอบแรกผมใช้ `${CLAUDE_HOME:-/dev/null}` เป็น trick ทำ optional mount ซึ่ง**ใช้ไม่ได้จริง** (bind char device ทับ dir) — ย้ายไป `docker-compose.override.yml.example` แทน

> ⚠️ และตอนแรกผม**รายงานว่า compose syntax ผ่านทั้งที่ไม่ผ่าน** เพราะ `&&` ต่อจาก `head` ไม่ใช่จาก compose — แก้แล้วโดยเช็ค exit code จริงทั้ง 4 profile combo

---

244 test ผ่าน
