### PR TITLE
feat(template): bot-service-v2 — project ที่ไม่มีโค้ดของ bot อยู่ข้างใน

### DIFF
--- a/botforge
+++ b/botforge
@@ -85,6 +85,7 @@ cmd_new() {
 
     # Select engine
     echo "  Engine:"
+    echo "    0) v2          — Botforge V2 (ไม่ copy โค้ด · เปลี่ยน runtime ได้ทีหลัง) [แนะนำ]"
     echo "    1) opencode    — Multi-model (Claude, GPT, Gemini, DeepSeek, Qwen, Groq)"
     echo "    2) claude-code — Claude only (Agent SDK, simpler, cost control)"
     echo "    3) gocode      — Go + OpenAI-compatible (DeepSeek, GPT, Qwen, Groq, Ollama)"
@@ -108,7 +109,32 @@ cmd_new() {
         7) engine="codex"; bot_template="bot-service-codex" ;;
         8) engine="copilot-cli"; bot_template="bot-service-copilot-cli" ;;
         9) engine="codex-appserver"; bot_template="bot-service-codex-appserver" ;;
+        0) engine="v2"; bot_template="bot-service-v2" ;;
     esac
+
+    # V2 ไม่ผูก engine กับ template — ถาม runtime แยก เปลี่ยนทีหลังได้ที่ .env
+    local v2_runtime="opencode"
+    local v2_tenant="$project_name"
+    if [[ "$engine" == "v2" ]]; then
+        echo ""
+        echo "  Runtime (เปลี่ยนทีหลังได้ที่ .env):"
+        echo "    1) opencode  2) claude  3) codex  4) adkcode"
+        read -rp "  Select [1]: " rt_choice
+        case "${rt_choice:-1}" in
+            2) v2_runtime="claude" ;;
+            3) v2_runtime="codex" ;;
+            4) v2_runtime="adkcode" ;;
+            *) v2_runtime="opencode" ;;
+        esac
+        echo ""
+        echo "  Tenant = ลูกค้า (bot หลายตัวของลูกค้าเดียวกันใช้ tenant เดียวกัน)"
+        read -rp "  Tenant [$project_name]: " v2_tenant
+        v2_tenant="${v2_tenant:-$project_name}"
+        if [[ ! "$v2_tenant" =~ ^[a-z0-9][a-z0-9_-]{0,62}$ ]]; then
+            print_error "tenant ต้องตรง identity/v1 Id pattern"
+            exit 1
+        fi
+    fi
 
     echo ""
 
@@ -163,6 +189,8 @@ cmd_new() {
             -e "s|{{TUNNEL_NAME}}|${project_name}|g" \
             -e "s|{{DOMAIN}}|${domain}|g" \
             -e "s|{{GITHUB_ORG}}|${github_org}|g" \
+            -e "s|{{RUNTIME}}|${v2_runtime}|g" \
+            -e "s|{{TENANT}}|${v2_tenant}|g" \
         {} +
 
     print_success "done"
@@ -296,6 +324,7 @@ detect_engine() {
 engine_to_template() {
     local engine="$1"
     case "$engine" in
+        v2)          echo "bot-service-v2" ;;
         opencode)    echo "bot-service-opencode" ;;
         claude-code) echo "bot-service-claude-code" ;;
         gocode)      echo "bot-service-gocode" ;;

--- a/botforge-deploy
+++ b/botforge-deploy
@@ -63,7 +63,12 @@ resolve_targets() {
 detect_engine() {
     local name="$1"
     local dir="$PROJECTS_DIR/$name/bot-service"
-    if [[ -f "$dir/server/api.py" ]]; then
+    # V2 ประกาศตัวเองด้วย botforge.yaml — ไม่มีโค้ดให้ sniff เพราะโค้ดอยู่ใน image
+    if [[ -f "$dir/botforge.yaml" ]]; then
+        local rt
+        rt=$(grep -oE '^runtime:[[:space:]]*"?[a-z-]+' "$dir/botforge.yaml" 2>/dev/null | grep -oE '[a-z-]+$')
+        echo "v2:${rt:-unknown}"
+    elif [[ -f "$dir/server/api.py" ]]; then
         echo "adkcode"
     elif [[ -f "$dir/server/go.mod" ]]; then
         echo "gocode"

--- a/docs/architecture/open-items.md
+++ b/docs/architecture/open-items.md
@@ -15,7 +15,9 @@ audit event 3 ใบ · model จริงตอบ · reply→push fallback ท
 ```
 
 **เหลือขั้นสุดท้ายที่ยังไม่ได้ยืนยัน:** ส่งถึง LINE จริง (ต้องมี channel token ของจริง)
-และยังไม่มี `docker-compose.yml` · ไม่มี template ให้ `botforge new` · ไม่มีเส้นทางย้าย 14 bot
+
+`docker-compose.yml` ✅ (compose profiles) · template ให้ `botforge new` ✅ (`bot-service-v2`)
+· **เส้นทางย้าย 14 bot ยังไม่มี**
 
 <details><summary>บันทึกเดิมก่อนแก้</summary>
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm test --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "conformance": "python3 conformance/drift_check.py && python3 conformance/payload_check.py",
-    "check": "npm run typecheck && npm test && npm run conformance"
+    "check": "npm run typecheck && npm test && npm run conformance",
+    "image": "docker build -f apps/line-bot/Dockerfile -t botforge/line-bot:v2 ."
   }
 }

--- a/templates/bot-service-v2/.env.example
+++ b/templates/bot-service-v2/.env.example
@@ -1,0 +1,43 @@
+# ── ตัวตนใน ecosystem — ห้ามเดา event/v1 บังคับให้ประกาศ ──
+BOTFORGE_TENANT_ID={{TENANT}}
+BOTFORGE_WORKSPACE_ID={{PROJECT_NAME}}
+
+# ── LINE ──
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_ACCESS_TOKEN=
+LINE_OA_URL=
+BOT_NAME={{PROJECT_NAME}}
+
+# ── runtime: opencode | codex | claude | adkcode ──
+# ต้องตรงกับ runtime ใน botforge.yaml และกับ COMPOSE_PROFILES ตอน up
+BOTFORGE_RUNTIME={{RUNTIME}}
+PROMPT_TIMEOUT_MS=120000
+
+# image ที่ build จาก repo ของ botforge — `npm run image` ที่ root
+BOTFORGE_IMAGE=botforge/line-bot:v2
+CONTAINER_PREFIX={{CONTAINER_PREFIX}}
+
+# ── opencode ──
+OPENCODE_PASSWORD=
+ANTHROPIC_API_KEY=
+DEEPSEEK_API_KEY=
+GOOGLE_API_KEY=
+QWEN_API_KEY=
+GROQ_API_KEY=
+OKMD_API_KEY=
+THAILLM_API_KEY=
+
+# ── codex (ต้องมี ~/.codex จาก host ผ่าน override) ──
+# CODEX_MODEL=o4-mini
+
+# ── claude (ANTHROPIC_API_KEY หรือ ~/.claude ผ่าน override) ──
+# CLAUDE_MODEL=sonnet
+# CLAUDE_MAX_TURNS=10
+# CLAUDE_MAX_BUDGET_USD=1.00
+
+# ── adkcode ──
+# SERVER_PASSWORD=
+
+# ── Cloudflare tunnel ──
+CLOUDFLARE_TUNNEL_TOKEN=
+GITHUB_TOKEN=

--- a/templates/bot-service-v2/.gitignore
+++ b/templates/bot-service-v2/.gitignore
@@ -1,0 +1,4 @@
+.env
+docker-compose.override.yml
+workspace/
+node_modules/

--- a/templates/bot-service-v2/CLAUDE.md
+++ b/templates/bot-service-v2/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md — {{PROJECT_NAME}}
+
+## Project Overview
+
+LINE Bot บน **Botforge V2** · **project นี้ไม่มีโค้ดของ bot** — มีแต่ config
+โค้ดอยู่ใน image `botforge/line-bot:v2` ที่ build จาก repo ของ botforge (`apps/line-bot`)
+
+## Commands
+
+```bash
+COMPOSE_PROFILES=opencode,tunnel docker compose up -d
+docker compose logs -f line-bot
+docker compose logs -f line-bot | grep '^{'     # audit event (event/v1)
+docker compose pull && docker compose up -d     # อัปเดตโค้ดของ bot
+docker compose down
+```
+
+## Architecture
+
+```
+LINE → Cloudflare Tunnel → line-bot (image, port 3000)
+                             ↕ RuntimePort
+                    opencode / codex / claude / adkcode
+```
+
+- `botforge.yaml` — บอกว่าเป็น V2 · runtime ไหน · tenant/workspace อะไร
+- `.env` — credential และ config ทั้งหมด
+- `docker-compose.yml` — profile ต่อ runtime
+- `../workspace/` — `AGENTS.md` และไฟล์ที่ agent ทำงานด้วย (repo แยก)
+
+## แก้โค้ดของ bot ที่ไหน
+
+**ไม่ใช่ที่นี่** — ที่ `packages/` หรือ `apps/line-bot` ใน repo ของ botforge แล้ว build image ใหม่
+ถ้าแก้ในโฟลเดอร์นี้จะหายตอน pull ครั้งถัดไป
+
+## GitHub
+
+- Bot config: `{{GITHUB_ORG}}/{{PROJECT_NAME}}`
+- Workspace: `{{GITHUB_ORG}}/{{PROJECT_NAME}}-workspace` (Private)

--- a/templates/bot-service-v2/README.md
+++ b/templates/bot-service-v2/README.md
@@ -1,0 +1,80 @@
+# {{PROJECT_NAME}}
+
+LINE Bot บน **Botforge V2** — webhook: `https://{{DOMAIN}}/webhook`
+
+## ไม่มีโค้ดใน project นี้
+
+นี่คือความต่างหลักจาก V1:
+
+| | V1 | V2 |
+| --- | --- | --- |
+| โค้ดของ bot | `src/index.ts` ~900 บรรทัด **copy มาไว้ทุก project** | อยู่ใน image `botforge/line-bot:v2` |
+| อัปเดต | `botforge sync --full` — **copy ทับไฟล์** | `docker compose pull` |
+| แก้ bug หนึ่งจุด | แตะ 23 ไฟล์ ใน 15 repo | แตะที่เดียว build image ใหม่ |
+| เปลี่ยน engine | เปลี่ยน template = สร้าง project ใหม่ | เปลี่ยน `BOTFORGE_RUNTIME` ใน `.env` |
+
+project นี้มีแค่ **config** — `.env` · `docker-compose.yml` · `botforge.yaml` · `workspace/`
+
+## เริ่มใช้
+
+```bash
+cp .env.example .env      # เติม LINE_CHANNEL_SECRET / ACCESS_TOKEN
+COMPOSE_PROFILES=opencode,tunnel docker compose up -d
+```
+
+| `BOTFORGE_RUNTIME` | `COMPOSE_PROFILES` ที่ต้องใส่ |
+| --- | --- |
+| `opencode` | `opencode` |
+| `adkcode` | `adkcode` |
+| `codex` · `claude` | ไม่ต้องใส่ profile ของ engine |
+
+เติม `,tunnel` เมื่อต้องการให้ LINE เข้าถึงได้จากอินเทอร์เน็ต
+
+## เปลี่ยน engine
+
+```bash
+# .env
+BOTFORGE_RUNTIME=claude
+```
+
+```bash
+docker compose down && COMPOSE_PROFILES=claude docker compose up -d
+```
+
+**ไม่ต้องสร้าง project ใหม่** — เป็นสิ่งที่ V1 ทำไม่ได้เพราะ engine ผูกกับ template
+
+## อัปเดตโค้ดของ bot
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+image build จาก repo ของ botforge (`npm run image` ที่ root ของ repo นั้น)
+
+## credential จาก host
+
+`~/.claude` · `~/.codex` · `~/.config/gcloud` ใส่ใน `docker-compose.override.yml`
+compose อ่านอัตโนมัติเมื่ออยู่โฟลเดอร์เดียวกัน
+
+```yaml
+services:
+  line-bot:
+    volumes:
+      - ${HOME}/.claude:/root/.claude
+```
+
+## workspace
+
+`../workspace/` เป็น repo แยก (private) — `AGENTS.md` กำหนด role และกติกาของ agent
+mount เข้าทั้ง `line-bot` และ container ของ engine ที่ path `/workspace`
+
+## audit event
+
+bot เขียน `event/v1` ลง stdout เป็น JSON บรรทัดละใบ
+
+```bash
+docker compose logs -f line-bot | grep '^{'
+```
+
+`BOTFORGE_TENANT_ID` และ `BOTFORGE_WORKSPACE_ID` **บังคับ** — ขาดแล้ว container จบด้วย exit 2
+ไม่ใช่สตาร์ทแล้วปล่อย event ที่ระบุ tenant ไม่ได้

--- a/templates/bot-service-v2/botforge.yaml
+++ b/templates/bot-service-v2/botforge.yaml
@@ -1,0 +1,19 @@
+# Botforge V2 project — ตัวบอกว่า project นี้ใช้ V2 ไม่ใช่ template แบบ copy โค้ด
+#
+# botforge-deploy อ่านไฟล์นี้เพื่อรู้ว่าเป็น V2 และรู้ว่าใช้ runtime ไหน
+# ไม่มีไฟล์นี้ = project แบบ V1 ที่ copy โค้ดมาทั้งชุด
+
+version: 2
+project: "{{PROJECT_NAME}}"
+
+# runtime: opencode | codex | claude | adkcode
+# ต้องตรงกับ BOTFORGE_RUNTIME ใน .env
+runtime: "{{RUNTIME}}"
+
+# ตัวตนใน ecosystem ตาม identity/v1 — tenant คือลูกค้า workspace คือ bot หนึ่งตัว
+tenant: "{{TENANT}}"
+workspace: "{{PROJECT_NAME}}"
+
+# โค้ดไม่ได้อยู่ใน project นี้ — อยู่ใน image
+# อัปเดต = pull image ใหม่ ไม่ใช่ botforge sync --full ทับไฟล์
+image: "botforge/line-bot:v2"

--- a/templates/bot-service-v2/docker-compose.yml
+++ b/templates/bot-service-v2/docker-compose.yml
@@ -1,0 +1,79 @@
+# {{PROJECT_NAME}} — Botforge V2
+#
+# ⚠️ **ไม่มีโค้ดใน project นี้** — โค้ดอยู่ใน image `${BOTFORGE_IMAGE}`
+#    ต่างจาก template V1 ที่ copy `src/index.ts` ~900 บรรทัดมาไว้ทุก project
+#    อัปเดต = `docker compose pull` ไม่ใช่ `botforge sync --full` ทับไฟล์
+#
+# รัน:
+#   COMPOSE_PROFILES=opencode,tunnel docker compose up -d
+#   COMPOSE_PROFILES=claude          docker compose up -d
+#
+# credential จาก host (~/.claude, ~/.codex, ~/.config/gcloud) ใส่ใน
+# docker-compose.override.yml — ดู .env.example
+
+name: {{CONTAINER_PREFIX}}
+
+services:
+  line-bot:
+    image: ${BOTFORGE_IMAGE:-botforge/line-bot:v2}
+    container_name: {{CONTAINER_PREFIX}}-line-bot
+    env_file: [.env]
+    environment:
+      - PORT=3000
+      - WORKSPACE_DIR=/workspace
+      - OPENCODE_URL=http://opencode:4096
+      - ADKCODE_URL=http://adkcode:8000
+    volumes:
+      - ${PROJECT_DIR:-../workspace}:/workspace
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  opencode:
+    profiles: [opencode]
+    image: ${OPENCODE_IMAGE:-ghcr.io/anomalyco/opencode:latest}
+    container_name: {{CONTAINER_PREFIX}}-opencode
+    command: ["serve", "--hostname=0.0.0.0", "--port=4096"]
+    working_dir: /workspace
+    environment:
+      - OPENCODE_SERVER_PASSWORD=${OPENCODE_PASSWORD:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - QWEN_API_KEY=${QWEN_API_KEY:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - OKMD_API_KEY=${OKMD_API_KEY:-}
+      - THAILLM_API_KEY=${THAILLM_API_KEY:-}
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+    volumes:
+      - ${PROJECT_DIR:-../workspace}:/workspace
+      - opencode-data:/root/.local/share/opencode
+      - opencode-state:/root/.local/state/opencode
+    restart: unless-stopped
+
+  adkcode:
+    profiles: [adkcode]
+    image: ${ADKCODE_IMAGE:-botforge/adkcode:v2}
+    container_name: {{CONTAINER_PREFIX}}-adkcode
+    environment:
+      - API_PASSWORD=${SERVER_PASSWORD:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+    volumes:
+      - ${PROJECT_DIR:-../workspace}:/workspace
+    restart: unless-stopped
+
+  cloudflared:
+    profiles: [tunnel]
+    image: cloudflare/cloudflared:latest
+    container_name: {{CONTAINER_PREFIX}}-tunnel
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on: [line-bot]
+    restart: unless-stopped
+
+volumes:
+  opencode-data:
+  opencode-state:


### PR DESCRIPTION
**จุดที่ V2 ต่างจาก V1 มากที่สุดในสายตาผู้ใช้**

| | V1 | V2 |
| --- | --- | --- |
| โค้ดของ bot | `src/index.ts` ~900 บรรทัด **copy มาไว้ทุก project** | อยู่ใน image `botforge/line-bot:v2` |
| อัปเดต | `botforge sync --full` — **copy ทับไฟล์** | `docker compose pull` |
| แก้ bug หนึ่งจุด | แตะ **23 ไฟล์ ใน 15 repo** | แตะที่เดียว build image ใหม่ |
| เปลี่ยน engine | **สร้าง project ใหม่** (engine ผูกกับ template) | แก้ `BOTFORGE_RUNTIME` ใน `.env` |
| ขนาด project | 13 ไฟล์ | **6 ไฟล์ 264 บรรทัด** |

## `botforge.yaml` — ตัวประกาศว่าเป็น V2

```yaml
version: 2
runtime: "claude"
tenant: "demo"
image: "botforge/line-bot:v2"
```

`botforge-deploy` อ่านไฟล์นี้แทนการ sniff โค้ด — **เพราะ V2 ไม่มีโค้ดให้ sniff**

## CLI

- `botforge new` เพิ่มตัวเลือก `0) v2` ไว้บนสุด · **ถาม runtime แยกจาก template** เพราะ V2 ไม่ผูกสองอย่างนี้เข้าด้วยกัน · ถาม tenant พร้อม validate ตาม `identity/v1` Id pattern
- `detect_engine` คืน `v2:<runtime>`
- `npm run image` ที่ root

## ทดสอบจริงด้วยการสร้าง project

```
botforge new demo-v2  (engine 0 · runtime claude · tenant demo)

6 ไฟล์ 264 บรรทัด · placeholder เหลือ 0
botforge.yaml → runtime: claude · tenant: demo
detect_engine → v2:claude

profile claude          → line-bot
profile opencode        → line-bot opencode
profile adkcode         → adkcode line-bot
profile opencode,tunnel → line-bot cloudflared opencode
```

ลบ demo project ทิ้งแล้ว

> ⚠️ รอบแรกแก้ CLI ไม่สำเร็จเพราะ anchor ไม่ match — ตอนอ่านไฟล์ผมใช้ `grep -v "^\s*$"` ตัดบรรทัดว่างออก เลยจำ layout ผิด

---

244 test ผ่าน
