### PR TITLE
feat(migrate): botforge-migrate + คู่มือย้าย 14 bot จาก V1 มา V2

### DIFF
--- a/botforge-migrate
+++ b/botforge-migrate
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# botforge-migrate — ย้าย project จาก V1 มา V2 โดยไม่แตะของเดิม
+#
+# หลักการ: **สร้างของใหม่คู่กัน ไม่แปลงของเดิมในที่**
+#   V1 ยังรันอยู่ตลอดจนกว่าจะสลับ tunnel และยืนยันว่าใช้ได้
+#   ถอยกลับ = ชี้ tunnel กลับไปที่ V1 ซึ่งยังไม่ถูกแตะเลย
+#
+#   botforge-migrate check [name|all]   รายงานความพร้อม — ไม่แก้อะไร
+#   botforge-migrate plan <name>        แสดงว่าจะทำอะไร — ไม่แก้อะไร
+#   botforge-migrate run <name>         สร้าง projects/<name>-v2/ จริง
+#
+# ⚠️ เครื่องมือนี้ copy ค่าจาก .env ของเดิม แต่ **ไม่พิมพ์ค่าออกหน้าจอ** ทุกกรณี
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECTS_DIR="${PROJECTS_DIR:-$SCRIPT_DIR/projects}"
+TEMPLATES_DIR="${TEMPLATES_DIR:-$SCRIPT_DIR/templates}"
+V2_TEMPLATE="$TEMPLATES_DIR/bot-service-v2"
+
+BOLD='\033[1m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; RED='\033[0;31m'; DIM='\033[2m'; NC='\033[0m'
+
+# engine ของ V1 → runtime ของ V2 · ว่าง = ยังไม่มี adapter
+engine_to_runtime() {
+    case "$1" in
+        opencode)         echo "opencode" ;;
+        claude-code)      echo "claude" ;;
+        adkcode)          echo "adkcode" ;;
+        codex)            echo "codex" ;;
+        codex-appserver)  echo "codex" ;;   # V2 ยุบสองตัวนี้เป็น adapter เดียว
+        *)                echo "" ;;
+    esac
+}
+
+detect_engine() {
+    local dir="$PROJECTS_DIR/$1/bot-service"
+    if   [[ -f "$dir/botforge.yaml" ]];  then echo "v2"
+    elif [[ -f "$dir/server/api.py" ]];  then echo "adkcode"
+    elif [[ -f "$dir/server/go.mod" ]];  then echo "gocode"
+    elif [[ -f "$dir/opencode.json" ]];  then echo "opencode"
+    elif grep -q "GEMINI_MODEL" "$dir/docker-compose.yml" 2>/dev/null; then echo "gemini-cli"
+    elif grep -q "QWEN_MODEL" "$dir/docker-compose.yml" 2>/dev/null; then echo "qwen-code"
+    elif grep -q "CODEX_APPSERVER_PORT" "$dir/docker-compose.yml" 2>/dev/null; then echo "codex-appserver"
+    elif grep -q "CODEX_MODEL" "$dir/docker-compose.yml" 2>/dev/null; then echo "codex"
+    elif grep -q "COPILOT_MODEL" "$dir/docker-compose.yml" 2>/dev/null; then echo "copilot-cli"
+    elif [[ -d "$dir/server" ]]; then echo "claude-code"
+    else echo "unknown"; fi
+}
+
+# tenant ที่แนะนำ = ส่วนหน้าก่อนขีดแรก · เป็นแค่ข้อเสนอ คนตัดสินใจเอง
+suggest_tenant() { echo "${1%%-*}"; }
+
+get_projects() {
+    [[ -d "$PROJECTS_DIR" ]] || return 0
+    for dir in "$PROJECTS_DIR"/*/; do
+        [[ -f "$dir/bot-service/docker-compose.yml" ]] && basename "$dir"
+    done
+}
+
+# อ่านค่าจาก .env โดยไม่พิมพ์ออกหน้าจอ
+env_get() {
+    local file="$1" key="$2"
+    [[ -f "$file" ]] || return 0
+    sed -n "s/^${key}=//p" "$file" | head -1
+}
+env_has() { [[ -n "$(env_get "$1" "$2")" ]]; }
+
+# key ที่ V2 ใช้ต่อได้ตรง ๆ
+COMMON_KEYS=(LINE_CHANNEL_ACCESS_TOKEN LINE_CHANNEL_SECRET LINE_OA_URL
+             CLOUDFLARE_TUNNEL_TOKEN GITHUB_TOKEN PROMPT_TIMEOUT_MS)
+OPENCODE_KEYS=(OPENCODE_PASSWORD ANTHROPIC_API_KEY DEEPSEEK_API_KEY GOOGLE_API_KEY
+               QWEN_API_KEY GROQ_API_KEY OKMD_API_KEY THAILLM_API_KEY)
+CLAUDE_KEYS=(ANTHROPIC_API_KEY CLAUDE_MODEL CLAUDE_MAX_TURNS CLAUDE_MAX_BUDGET_USD)
+ADKCODE_KEYS=(GOOGLE_API_KEY)
+CODEX_KEYS=(CODEX_MODEL)
+
+# key ที่ V2 ยังไม่รู้จัก — ต้องบอกผู้ใช้ ไม่ใช่ทิ้งเงียบ
+unmapped_keys() {
+    local file="$1" runtime="$2" known=() k
+    known=("${COMMON_KEYS[@]}" PORT PROJECT_DIR API_PASSWORD)
+    case "$runtime" in
+        opencode) known+=("${OPENCODE_KEYS[@]}") ;;
+        claude)   known+=("${CLAUDE_KEYS[@]}") ;;
+        adkcode)  known+=("${ADKCODE_KEYS[@]}") ;;
+        codex)    known+=("${CODEX_KEYS[@]}") ;;
+    esac
+    while IFS= read -r k; do
+        local found=0
+        for kk in "${known[@]}"; do [[ "$k" == "$kk" ]] && { found=1; break; }; done
+        [[ $found -eq 0 ]] && echo "$k"
+    done < <(grep -oE '^[A-Z_]+=' "$file" 2>/dev/null | tr -d '=')
+}
+
+cmd_check() {
+    local target="${1:-all}" names
+    if [[ "$target" == "all" ]]; then names=$(get_projects); else names="$target"; fi
+
+    printf "  %-20s %-16s %-10s %-10s %s\n" "project" "engine (V1)" "runtime" "tenant" "สถานะ"
+    printf "  %s\n" "$(printf '─%.0s' {1..76})"
+    local ready=0 blocked=0
+    for name in $names; do
+        local engine runtime tenant status
+        engine=$(detect_engine "$name")
+        runtime=$(engine_to_runtime "$engine")
+        tenant=$(suggest_tenant "$name")
+        if [[ "$engine" == "v2" ]]; then
+            status="${DIM}เป็น V2 อยู่แล้ว${NC}"; runtime="-"; tenant="-"
+        elif [[ -z "$runtime" ]]; then
+            status="${RED}ยังไม่มี adapter${NC}"; runtime="-"; blocked=$((blocked+1))
+        elif [[ ! -f "$PROJECTS_DIR/$name/bot-service/.env" ]]; then
+            status="${YELLOW}ไม่มี .env${NC}"; blocked=$((blocked+1))
+        else
+            status="${GREEN}พร้อมย้าย${NC}"; ready=$((ready+1))
+        fi
+        printf "  %-20s %-16s %-10s %-10s %b\n" "$name" "$engine" "$runtime" "$tenant" "$status"
+    done
+    printf "  %s\n" "$(printf '─%.0s' {1..76})"
+    echo -e "  พร้อมย้าย ${BOLD}${ready}${NC} · ติดปัญหา ${BOLD}${blocked}${NC}"
+    [[ $blocked -gt 0 ]] && echo -e "  ${DIM}engine ที่ยังไม่มี adapter: copilot-cli · gocode · gemini-cli · qwen-code${NC}"
+    return 0
+}
+
+cmd_plan() {
+    local name="${1:?ต้องระบุชื่อ project}"
+    local src="$PROJECTS_DIR/$name/bot-service"
+    [[ -d "$src" ]] || { echo -e "  ${RED}ไม่พบ project $name${NC}"; exit 1; }
+
+    local engine runtime tenant dst env_file
+    engine=$(detect_engine "$name")
+    runtime=$(engine_to_runtime "$engine")
+    tenant="${TENANT:-$(suggest_tenant "$name")}"
+    dst="$PROJECTS_DIR/${name}-v2"
+    env_file="$src/.env"
+
+    echo -e "  ${BOLD}$name${NC} → โฟลเดอร์ ${BOLD}${name}-v2${NC} · workspace_id ยังเป็น ${BOLD}${name}${NC}"
+    echo "    engine V1 : $engine"
+    if [[ -z "$runtime" ]]; then
+        echo -e "    ${RED}ยังไม่มี adapter สำหรับ $engine — ย้ายไม่ได้${NC}"
+        exit 1
+    fi
+    echo "    runtime V2: $runtime"
+    echo "    tenant    : $tenant   (ตั้งเองได้ด้วย TENANT=... )"
+    echo "    workspace : $name     (คงเดิม — audit event จะได้ต่อเนื่อง)"
+    echo "    ปลายทาง   : $dst"
+    echo ""
+    echo "    จะทำ:"
+    echo "      1. สร้าง $dst/bot-service จาก templates/bot-service-v2"
+    echo "      2. copy ค่าจาก .env เดิมเข้า .env ใหม่ (ไม่พิมพ์ค่าออกหน้าจอ)"
+    echo "      3. copy workspace/ ของเดิมมาเป็นของใหม่"
+    echo "      4. ไม่แตะ $name เดิมเลย — ยังรันต่อได้"
+    echo ""
+    if [[ -f "$env_file" ]]; then
+        local n_map=0 k
+        for k in "${COMMON_KEYS[@]}"; do env_has "$env_file" "$k" && n_map=$((n_map+1)); done
+        echo "    key ที่ย้ายได้: $n_map (common) + ของ $runtime"
+        local unmapped
+        unmapped=$(unmapped_keys "$env_file" "$runtime" | tr '\n' ' ')
+        [[ -n "${unmapped// /}" ]] && echo -e "    ${YELLOW}key ที่ V2 ยังไม่รู้จัก: ${unmapped}${NC}"
+    else
+        echo -e "    ${YELLOW}ไม่มี .env เดิม — ต้องกรอกเอง${NC}"
+    fi
+}
+
+cmd_run() {
+    local name="${1:?ต้องระบุชื่อ project}"
+    local src="$PROJECTS_DIR/$name/bot-service"
+    local src_ws="$PROJECTS_DIR/$name/workspace"
+    [[ -d "$src" ]] || { echo -e "  ${RED}ไม่พบ project $name${NC}"; exit 1; }
+
+    local engine runtime tenant dst
+    engine=$(detect_engine "$name")
+    runtime=$(engine_to_runtime "$engine")
+    [[ -n "$runtime" ]] || { echo -e "  ${RED}ยังไม่มี adapter สำหรับ $engine${NC}"; exit 1; }
+    tenant="${TENANT:-$(suggest_tenant "$name")}"
+    dst="$PROJECTS_DIR/${name}-v2"
+    [[ -e "$dst" ]] && { echo -e "  ${RED}$dst มีอยู่แล้ว — ลบก่อนถ้าจะทำใหม่${NC}"; exit 1; }
+
+    # domain เดิม — webhook URL ต้องไม่เปลี่ยนตอนสลับ tunnel
+    # ⚠️ ต้องมี `|| true` เพราะ set -o pipefail ทำให้ grep ที่ไม่เจอไฟล์
+    #    ทำให้ทั้ง assignment fail แล้ว set -e ตัดจบเงียบ ๆ
+    local domain=""
+    if compgen -G "$src/*.md" > /dev/null 2>&1; then
+        domain=$(grep -ohE '[a-z0-9.-]+\.[a-z]{2,}/webhook' "$src"/*.md 2>/dev/null | head -1 | sed 's|/webhook||') || true
+    fi
+    domain="${DOMAIN:-${domain:-$name}}"
+
+    # ⚠️ ชื่อโฟลเดอร์และ container ใส่ -v2 เพื่อให้รันคู่กับของเดิมได้
+    #    แต่ **workspace_id ต้องเป็นชื่อเดิม** ไม่งั้น audit event ก่อน/หลังย้าย
+    #    จะกลายเป็นคนละ workspace ในสายตา identity/v1 และความต่อเนื่องขาด
+    local dir_name="${name}-v2"      # โฟลเดอร์ + container prefix
+    local workspace_id="$name"       # ตัวตนใน ecosystem — คงเดิมตลอดการย้าย
+
+    echo -n "  สร้าง project ใหม่...     "
+    mkdir -p "$dst/bot-service"
+    cp -r "$V2_TEMPLATE/." "$dst/bot-service/"
+    find "$dst/bot-service" -type f \( -name "*.yml" -o -name "*.yaml" -o -name "*.md" -o -name "*.example" -o -name ".gitignore" \) -exec \
+        sed -i -e "s|{{PROJECT_NAME}}|${workspace_id}|g" \
+               -e "s|{{CONTAINER_PREFIX}}|${dir_name}|g" \
+               -e "s|{{TENANT}}|${tenant}|g" \
+               -e "s|{{RUNTIME}}|${runtime}|g" \
+               -e "s|{{DOMAIN}}|${domain}|g" \
+               -e "s|{{GITHUB_ORG}}|botforge|g" {} +
+    echo -e "${GREEN}done${NC}"
+
+    echo -n "  ย้ายค่าจาก .env เดิม...   "
+    local env_src="$src/.env" env_dst="$dst/bot-service/.env"
+    cp "$dst/bot-service/.env.example" "$env_dst"
+    if [[ -f "$env_src" ]]; then
+        local keys=("${COMMON_KEYS[@]}")
+        case "$runtime" in
+            opencode) keys+=("${OPENCODE_KEYS[@]}") ;;
+            claude)   keys+=("${CLAUDE_KEYS[@]}") ;;
+            adkcode)  keys+=("${ADKCODE_KEYS[@]}") ;;
+            codex)    keys+=("${CODEX_KEYS[@]}") ;;
+        esac
+        local k v
+        for k in "${keys[@]}"; do
+            v=$(env_get "$env_src" "$k") || true
+            [[ -n "$v" ]] || continue
+            if grep -q "^${k}=" "$env_dst"; then
+                # ใช้ python เพราะค่ามีอักขระพิเศษได้ sed จะเพี้ยน
+                K="$k" V="$v" F="$env_dst" python3 - <<'PY'
+import os, re
+k, v, f = os.environ["K"], os.environ["V"], os.environ["F"]
+lines = open(f).read().split("\n")
+out = [f"{k}={v}" if re.match(rf"^{re.escape(k)}=", l) else l for l in lines]
+open(f, "w").write("\n".join(out))
+PY
+            else
+                printf '%s=%s\n' "$k" "$v" >> "$env_dst"
+            fi
+        done
+        # API_PASSWORD ของ V1 = SERVER_PASSWORD ของ V2
+        v=$(env_get "$env_src" "API_PASSWORD") || true
+        [[ -n "$v" ]] && printf 'SERVER_PASSWORD=%s\n' "$v" >> "$env_dst"
+    fi
+    chmod 600 "$env_dst"
+    echo -e "${GREEN}done${NC}"
+
+    echo -n "  copy workspace...        "
+    if [[ -d "$src_ws" ]]; then
+        cp -r "$src_ws" "$dst/workspace"
+        rm -rf "$dst/workspace/.git"
+    else
+        mkdir -p "$dst/workspace"
+        cp -r "$TEMPLATES_DIR/workspace/." "$dst/workspace/" 2>/dev/null || true
+    fi
+    echo -e "${GREEN}done${NC}"
+
+    local unmapped=""
+    [[ -f "$env_src" ]] && unmapped=$(unmapped_keys "$env_src" "$runtime" | tr '\n' ' ')
+
+    echo ""
+    echo -e "  ${GREEN}${BOLD}สร้างแล้ว${NC} — ${BOLD}$name เดิมยังไม่ถูกแตะ ยังรันอยู่${NC}"
+    echo ""
+    [[ -n "${unmapped// /}" ]] && echo -e "  ${YELLOW}key ที่ไม่ได้ย้ายเพราะ V2 ยังไม่รู้จัก: ${unmapped}${NC}" && echo ""
+    echo "  ขั้นถัดไป:"
+    echo "    1. npm run image                        # build botforge/line-bot:v2"
+    echo "    2. cd $dst/bot-service"
+    echo "    3. ตรวจ .env  แล้ว COMPOSE_PROFILES=$runtime docker compose up -d"
+    echo "    4. ทดสอบด้วย webhook ปลอมก่อน (ยังไม่ต้องสลับ tunnel)"
+    echo "    5. พอมั่นใจ ค่อยสลับ tunnel มาที่ตัวใหม่ แล้วหยุดตัวเดิม"
+    echo ""
+    echo -e "  ${DIM}ถอยกลับ = ชี้ tunnel กลับไปที่ $name ซึ่งยังไม่ถูกแตะเลย${NC}"
+}
+
+case "${1:-check}" in
+    check) shift; cmd_check "${1:-all}" ;;
+    plan)  shift; cmd_plan "${1:-}" ;;
+    run)   shift; cmd_run "${1:-}" ;;
+    *)
+        echo "ใช้: botforge-migrate {check [name|all] | plan <name> | run <name>}"
+        echo "     TENANT=<ชื่อลูกค้า> botforge-migrate run <name>"
+        exit 1 ;;
+esac

--- a/docs/architecture/migration.md
+++ b/docs/architecture/migration.md
@@ -1,0 +1,142 @@
+# ย้าย 14 bot จาก V1 มา V2
+
+**2026-08-24** · เครื่องมือ: [`botforge-migrate`](../../botforge-migrate)
+
+---
+
+## หลักการ — สร้างของใหม่คู่กัน ไม่แปลงของเดิมในที่
+
+```
+projects/legal-opencode/       ← V1 ยังรันอยู่ ไม่ถูกแตะเลย
+projects/legal-opencode-v2/    ← V2 สร้างใหม่ รันคู่กันได้
+```
+
+container คนละชื่อ (`legal-opencode-*` กับ `legal-opencode-v2-*`) จึงขึ้นพร้อมกันได้
+**ถอยกลับ = ชี้ tunnel กลับไปที่ตัวเดิม** ซึ่งยังไม่ถูกแตะ
+
+> ไม่มีขั้นตอนไหนที่แก้ของเดิม จนกว่าคุณจะสั่งหยุดมันเอง
+
+---
+
+## ตัวตนต้องต่อเนื่อง
+
+| | ค่า |
+| --- | --- |
+| โฟลเดอร์ · container prefix | `legal-opencode-v2` |
+| **`BOTFORGE_WORKSPACE_ID`** | **`legal-opencode`** — ชื่อเดิม |
+| `BOTFORGE_TENANT_ID` | `legal` |
+
+**`workspace_id` ต้องเป็นชื่อเดิม** ไม่งั้น audit event ก่อนและหลังย้ายจะกลายเป็นคนละ workspace
+ในสายตา `identity/v1` และความต่อเนื่องขาด — โฟลเดอร์เปลี่ยนได้ ตัวตนเปลี่ยนไม่ได้
+
+> จุดนี้รอบแรกทำผิด (`workspace_id` ติด `-v2` ไปด้วย) แล้วแก้
+
+---
+
+## สถานะความพร้อม — ตรวจจริงเมื่อ 2026-08-24
+
+```
+พร้อมย้าย 13 · ติดปัญหา 1
+```
+
+| engine V1 | จำนวน | runtime V2 | |
+| --- | ---: | --- | :-: |
+| `opencode` | 9 | `opencode` | ✅ |
+| `claude-code` | 2 | `claude` | ✅ |
+| `adkcode` | 2 | `adkcode` | ✅ |
+| **`copilot-cli`** | **1** | — | ❌ **ยังไม่มี adapter** |
+
+`legal-copilot` ย้ายไม่ได้จนกว่าจะมี `adapter-copilot` — ต่างจาก `claude-code` แค่ 41 diff-lines
+จึงน่าจะเร็ว แต่ตอนนี้พักไว้ตามที่ตกลง
+
+> `codex-appserver` ย้ายได้ด้วย — V2 ยุบมันกับ `codex` เป็น adapter เดียวแล้ว
+
+---
+
+## ขั้นตอน
+
+### 1. ดูภาพรวมก่อน — ไม่แก้อะไร
+
+```bash
+./botforge-migrate check all
+```
+
+### 2. ดูว่าจะทำอะไรกับตัวหนึ่ง — ไม่แก้อะไร
+
+```bash
+./botforge-migrate plan legal-opencode
+```
+
+บอกด้วยว่ามี key ไหนใน `.env` ที่ V2 **ยังไม่รู้จัก** — จะได้ไม่หายเงียบ
+
+### 3. สร้างของใหม่
+
+```bash
+TENANT=legal ./botforge-migrate run legal-opencode
+```
+
+- สร้าง `projects/legal-opencode-v2/` จาก `templates/bot-service-v2`
+- copy ค่าจาก `.env` เดิม (**ไม่พิมพ์ค่าออกหน้าจอทุกกรณี** · `.env` ใหม่ตั้ง `chmod 600`)
+- copy `workspace/` แล้ว **ลบ `.git` ออก** เพื่อเริ่ม history ใหม่ ไม่ลาก history เดิมมาปน
+- `API_PASSWORD` ของ V1 → `SERVER_PASSWORD` ของ V2
+
+### 4. build image แล้วลองรัน — ยังไม่สลับ tunnel
+
+```bash
+npm run image
+cd projects/legal-opencode-v2/bot-service
+COMPOSE_PROFILES=opencode docker compose up -d
+```
+
+ทดสอบด้วย webhook ที่เซ็นเองก่อน (ดู [`apps/line-bot/README.md`](../../apps/line-bot/README.md))
+
+### 5. สลับ tunnel
+
+ตัวใหม่ใช้ `CLOUDFLARE_TUNNEL_TOKEN` เดิม — เปิดตัวใหม่แล้วหยุด `cloudflared` ของตัวเดิม
+webhook URL ไม่เปลี่ยน
+
+### 6. หยุดตัวเดิม (เมื่อมั่นใจแล้วเท่านั้น)
+
+```bash
+./botforge-deploy down legal-opencode
+```
+
+**อย่าลบ** — เก็บไว้เป็นทางถอยจนกว่าจะผ่านไปสักระยะ
+
+---
+
+## `.env` ที่ย้ายได้
+
+| กลุ่ม | key |
+| --- | --- |
+| ทุก engine | `LINE_CHANNEL_ACCESS_TOKEN` `LINE_CHANNEL_SECRET` `LINE_OA_URL` `CLOUDFLARE_TUNNEL_TOKEN` `GITHUB_TOKEN` `PROMPT_TIMEOUT_MS` |
+| `opencode` | `OPENCODE_PASSWORD` + API key ของ 7 provider |
+| `claude` | `ANTHROPIC_API_KEY` `CLAUDE_MODEL` `CLAUDE_MAX_TURNS` `CLAUDE_MAX_BUDGET_USD` |
+| `adkcode` | `GOOGLE_API_KEY` |
+| `codex` | `CODEX_MODEL` |
+
+key ที่ไม่อยู่ในรายการนี้ **ไม่ถูกย้าย และเครื่องมือจะเตือน** เช่น `ADKCODE_MODEL_SMART` ·
+`ADKCODE_MODEL_FAST` ที่ V2 ยังไม่รองรับ · `GH_CONFIG_DIR` ของ copilot
+
+---
+
+## สิ่งที่ได้หลังย้าย
+
+| | V1 | V2 |
+| --- | --- | --- |
+| ไฟล์ใน project | 13 (รวม `src/index.ts` ~900 บรรทัด) | **6 · 264 บรรทัด** |
+| อัปเดตโค้ด | `botforge sync --full` copy ทับ | `docker compose pull` |
+| เปลี่ยน engine | สร้าง project ใหม่ | แก้ `BOTFORGE_RUNTIME` |
+| audit event | ไม่มีเลย | `event/v1` ครบทุกจังหวะ |
+| request queue | **ไม่มีใน `opencode`** | มีทุก engine |
+| error hints ไทย | **ไม่มีใน `opencode`** | มีทุก engine |
+
+สามข้อล่างคือของที่ `opencode` ตกหล่นมาตลอด และ 9 ใน 14 bot ใช้ `opencode`
+
+---
+
+## ยังไม่ได้ทำ
+
+- **ยังไม่ได้ย้ายจริงสักตัว** — เครื่องมือทดสอบด้วย fixture สังเคราะห์ ไม่ได้แตะ 14 bot จริง
+- ยังไม่ได้ยิงกับ LINE channel จริง
+- `adapter-copilot` สำหรับ `legal-copilot`

--- a/docs/architecture/open-items.md
+++ b/docs/architecture/open-items.md
@@ -17,7 +17,7 @@ audit event 3 ใบ · model จริงตอบ · reply→push fallback ท
 **เหลือขั้นสุดท้ายที่ยังไม่ได้ยืนยัน:** ส่งถึง LINE จริง (ต้องมี channel token ของจริง)
 
 `docker-compose.yml` ✅ (compose profiles) · template ให้ `botforge new` ✅ (`bot-service-v2`)
-· **เส้นทางย้าย 14 bot ยังไม่มี**
+· เส้นทางย้าย 14 bot ✅ ([`migration.md`](migration.md) + `botforge-migrate`) — **แต่ยังไม่ได้ย้ายจริงสักตัว**
 
 <details><summary>บันทึกเดิมก่อนแก้</summary>
 


### PR DESCRIPTION
## หลักการ — สร้างของใหม่คู่กัน ไม่แปลงของเดิมในที่

```
projects/legal-opencode/       ← V1 ยังรันอยู่ ไม่ถูกแตะเลย
projects/legal-opencode-v2/    ← V2 สร้างใหม่ container คนละชื่อ รันคู่กันได้
```

**ถอยกลับ = ชี้ tunnel กลับไปที่ตัวเดิม** · ไม่มีขั้นตอนไหนแก้ของเดิมจนกว่าคนจะสั่งหยุดมันเอง

## ตัวตนต้องต่อเนื่อง — จุดที่รอบแรกผมทำผิดแล้วแก้

| | ค่า |
| --- | --- |
| โฟลเดอร์ · container prefix | `legal-opencode-v2` |
| **`BOTFORGE_WORKSPACE_ID`** | **`legal-opencode`** — ชื่อเดิม |

ถ้า `workspace_id` ติด `-v2` ไปด้วย **audit event ก่อนและหลังย้ายจะเป็นคนละ workspace ในสายตา `identity/v1`** — โฟลเดอร์เปลี่ยนได้ ตัวตนเปลี่ยนไม่ได้

## ตรวจจริงกับ 14 bot แล้ว (read-only)

```
พร้อมย้าย 13 · ติดปัญหา 1
```

| engine V1 | จำนวน | runtime V2 | |
| --- | ---: | --- | :-: |
| `opencode` | 9 | `opencode` | ✅ |
| `claude-code` | 2 | `claude` | ✅ |
| `adkcode` | 2 | `adkcode` | ✅ |
| **`copilot-cli`** | **1** | — | ❌ ยังไม่มี adapter |

## คำสั่ง

| | |
| --- | --- |
| `check [name\|all]` | รายงานความพร้อม — ไม่แก้อะไร |
| `plan <name>` | แสดงว่าจะทำอะไร + **key ที่ V2 ยังไม่รู้จัก** — ไม่แก้อะไร |
| `run <name>` | สร้างของใหม่ |

**ไม่พิมพ์ค่าใน `.env` ออกหน้าจอทุกกรณี** · `.env` ใหม่ `chmod 600` · copy `workspace/` แล้วลบ `.git` เพื่อไม่ลาก history เดิมมาปน

## bug ที่เจอตอนเขียน

`set -o pipefail` ทำให้ `grep` ที่ไม่เจอไฟล์ทำให้ทั้ง assignment fail แล้ว `set -e` **ตัดจบเงียบ ๆ ไม่มี error ออกมาเลย** — ต้อง `bash -x` ถึงเห็น

> และระหว่างทางผม**เผลอสร้าง branch ใน worktree ของ `main`** — กลับไป `main` และลบ branch ทิ้งแล้ว ของเดิมไม่เสียหาย · ระหว่างนั้นพบว่า local `main` ตามหลัง `origin/main` อยู่ 4 commit จึง fast-forward ให้ตรง

## ⚠️ ยังไม่ได้ย้ายจริงสักตัว

ทดสอบด้วย fixture สังเคราะห์ **ไม่ได้แตะ 14 bot จริง** — การย้ายจริงเป็นการตัดสินใจของเจ้าของ bot

---

244 test ผ่าน
