### PR TITLE
docs: ปิด route legal-services-server ที่ Caddy แล้ว

### DIFF
--- a/docs/architecture/domain-change.md
+++ b/docs/architecture/domain-change.md
@@ -150,5 +150,8 @@ tunnel ชื่อ `icbserv-ssh` ในบัญชีเดียวกัน�
 
 ## ที่ยังค้างอยู่ ไม่เกี่ยวกับการย้าย
 
-`legal-services-server.eformservice.com` เปิดโล่งอยู่ (ดู [`open-items.md`](open-items.md))
-ไม่เกี่ยวกับ domain ที่หมดอายุ และไม่หายไปเองหลังย้าย
+`legal-services-server.eformservice.com` **ปิดไปแล้ว 2026-08-24** — comment ไว้ใน
+`/opt/docker-test/central-proxy/Caddyfile` (สำรอง `.bak-20260824`) ดู [`open-items.md`](open-items.md)
+
+`legal-services.eformservice.com` ยังเปิดอยู่ตามเดิม และ LINE ยังใช้
+`legal.thaidirection.com/line/webhook` — ทั้งคู่ไม่ผูกกับ `sumana.*` การย้าย domain ไม่กระทบ

--- a/docs/architecture/open-items.md
+++ b/docs/architecture/open-items.md
@@ -194,7 +194,7 @@ claude-code · copilot-cli ไม่มีปัญหานี้ — server �
 Cloudflare Access หน้า `<name>-server.<domain>` เพราะ LINE bot ไม่ได้วิ่งผ่าน tunnel
 (คุยกันในเครือข่าย docker) จึงไม่กระทบ **ยังไม่ได้ทำและยังไม่ได้ตรวจว่า plan รองรับ**
 
-## 🔴 legal-services เปิดโล่งอยู่จริงตอนนี้ — ไม่เกี่ยวกับ domain ที่หมดอายุ
+## ✅ legal-services เคยเปิดโล่ง — ปิด route ที่ Caddy แล้ว 2026-08-24
 
 ยิงจากภายนอกเมื่อ 2026-08-24:
 
@@ -217,9 +217,22 @@ LINE webhook ของมันชี้ hostname ที่สาม `https://le
 `API_PASSWORD` ตั้งไว้ในไฟล์แล้วแต่ container ยังไม่ได้ restart — และถึง restart
 ก็ยังไม่พอเพราะ `api.py:85` ข้าม auth ให้ `/dev-ui*` อยู่แล้ว (ดูหัวข้อ adkcode ข้างบน)
 
-**ทางแก้ที่แนะนำ:** basic auth ที่ Caddy เฉพาะ hostname `-server` — UI ยังใช้ได้
-(เบราว์เซอร์ขึ้นกล่องให้กรอก) และไม่กระทบ LINE ที่ออกคนละ hostname
-**ยังไม่ได้ทำ** ต้องให้เจ้าของเคาะก่อน เพราะ Caddy ตัวนี้เสิร์ฟเว็บอื่นอีกหลายตัว
+### ที่ทำจริง — ปิด route ไปเลย
+
+เจ้าของเลือกปิดทิ้ง ไม่ใช่ใส่ basic auth บล็อก
+`legal-services-server.eformservice.com` ใน `/opt/docker-test/central-proxy/Caddyfile`
+ถูก comment ไว้พร้อมเหตุผล (สำรอง `Caddyfile.bak-20260824`) แล้ว `caddy reload` แบบ graceful
+
+ยืนยันหลังปิด: `/dev-ui/` และ `/list-apps` → **connection ไม่ติด** ·
+`legal-services.eformservice.com` ยัง 200 · `legal.eformservice.com` `pupanha` `watjan`
+`co-train` ยัง 200 · POST ปลอมไป `/webhook` ได้ 403 (signature validation ทำงาน) ·
+`legal.thaidirection.com/line/webhook` ซึ่งเป็นทางที่ LINE ใช้จริง ยัง 200
+
+`diff` ยืนยันว่าแตะบล็อกเดียว (`propspace-v15.eformservice.com` ที่ยิงไม่ติดคือ
+**ไม่มี DNS record มาแต่เดิม** ไม่เกี่ยวกับการแก้ครั้งนี้)
+
+**จะเปิดกลับ** ต้องใส่ `basicauth` ที่บล็อกนั้นก่อน — ตั้ง `API_PASSWORD` อย่างเดียวไม่พอ
+เพราะ `api.py:85` ข้าม auth ให้ `/dev-ui*` อยู่แล้ว
 
 ---
 


### PR DESCRIPTION
ADK dev UI ของ `legal-services` เปิดให้อินเทอร์เน็ตยิงได้โดยไม่ต้อง auth
เจ้าของเลือก **ปิด route ทิ้ง** ไม่ใช่ใส่ basic auth

comment บล็อก `legal-services-server.eformservice.com` ใน `/opt/docker-test/central-proxy/Caddyfile`
พร้อมเหตุผล · สำรอง `.bak-20260824` · `caddy validate` ผ่าน · `caddy reload` แบบ graceful

| | ก่อน | หลัง |
|---|---|---|
| `legal-services-server…/dev-ui/` | 200 | **ต่อไม่ติด** |
| `legal-services-server…/list-apps` | 200 | **ต่อไม่ติด** |
| `legal-services.eformservice.com` | 200 | 200 |
| `legal` · `pupanha` · `watjan` · `co-train` | — | 200 |
| POST ปลอม → `/webhook` | — | 403 (signature validation ทำงาน) |
| `legal.thaidirection.com/line/webhook` (LINE ใช้จริง) | 200 | 200 |

`diff` ยืนยันว่าแตะบล็อกเดียว — `propspace-v15.eformservice.com` ที่ยิงไม่ติด
คือ **ไม่มี DNS record มาแต่เดิม** ไม่เกี่ยวกับการแก้ครั้งนี้

จะเปิดกลับต้องใส่ `basicauth` ที่บล็อกนั้นก่อน — ตั้ง `API_PASSWORD` อย่างเดียวไม่พอ
เพราะ `api.py:85` ข้าม auth ให้ `/dev-ui*` อยู่แล้ว

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTaqjACHoPorgseAtw6Nvc