### PR TITLE
fix(deploy): _replace_in_file ต้องตาม symlink + default domain เป็น sumana.org

### DIFF
--- a/botforge
+++ b/botforge
@@ -11,7 +11,7 @@ PROJECTS_DIR="${PROJECTS_DIR:-$SCRIPT_DIR/projects}"
 
 # Defaults
 DEFAULT_GITHUB_ORG="monthop-gmail"
-DEFAULT_DOMAIN_SUFFIX="sumana.online"
+DEFAULT_DOMAIN_SUFFIX="sumana.org"
 
 # --- Colors ---
 RED='\033[0;31m'

--- a/botforge-deploy
+++ b/botforge-deploy
@@ -10,7 +10,7 @@ PROJECTS_DIR="${PROJECTS_DIR:-$SCRIPT_DIR/projects}"
 CONFIG_FILE="${CONFIG_FILE:-$SCRIPT_DIR/.botforge-deploy.env}"
 
 # Default domain suffix
-DEFAULT_DOMAIN_SUFFIX="sumana.online"
+DEFAULT_DOMAIN_SUFFIX="sumana.org"
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -855,6 +855,10 @@ _line_token_of() { _env_get "$PROJECTS_DIR/$1/bot-service/.env" LINE_CHANNEL_ACC
 #    mv สร้าง inode ใหม่ ตัวที่กำลังรันยังถือ fd เก่าไว้จนจบ
 _replace_in_file() {
     local file="$1" from="$2" to="$3" tmp
+    # ⚠️ ถ้า $file เป็น symlink ต้องตามไปแก้ไฟล์จริง ไม่งั้น mv ข้างล่างจะเอาไฟล์ธรรมดา
+    #    ไปทับตัว symlink ทิ้ง แล้วของจริงยังเป็นค่าเก่า (เจอมาแล้วกับ .botforge-deploy.env
+    #    ตอน worktree v2 symlink ไปหา checkout หลัก)
+    [[ -L "$file" ]] && file=$(readlink -f "$file")
     tmp=$(mktemp "${file}.XXXXXX") || return 1
     sed "s|${from//./\\.}|${to}|g" "$file" > "$tmp" || { rm -f "$tmp"; return 1; }
     chmod --reference="$file" "$tmp" 2>/dev/null || true


### PR DESCRIPTION
ย้าย domain จริงแล้ววันนี้ `sumana.online` → `sumana.org` เจอ bug ระหว่างทาง

## bug: `mv` ทับ symlink ทิ้ง

`_replace_in_file` ใช้ tmp+mv **โดยตั้งใจ** (สคริปต์แก้ตัวเองระหว่างรัน เขียนทับ inode เดิมจะรันขยะต่อ)
แต่ถ้าเป้าหมายเป็น symlink การ `mv` จะเอาไฟล์ธรรมดาไปทับตัว symlink ทิ้ง — ไฟล์จริงยังเป็นค่าเก่า

เจอกับ `.botforge-deploy.env` ที่ worktree v2 symlink ไปหา checkout หลัก
ผลคือ v2 ได้ค่าใหม่ แต่ checkout หลักยังเป็น `sumana.online`

แก้ด้วย `readlink -f` ก่อน `mktemp` — ทดสอบแล้ว symlink รอด ไฟล์จริงเปลี่ยน
(`projects/` ไม่โดนเพราะ tool เขียนไฟล์ *ข้างใน* ไม่ใช่ตัว symlink)

## ผลการย้ายจริง

| | |
|---|---|
| LINE webhook | 13 channel ย้ายแล้ว · ยืนยันด้วย `domain show` |
| `legal-services` | **ถูกข้ามอัตโนมัติ** เพราะชี้ `legal.thaidirection.com` — กลไกกันเขียนทับทำงานถูก |
| DNS | 28 record สร้างครบ · resolve ได้จริง |
| record เดิมของ `sumana.org` | เว็บ + MX×5 + SPF/DKIM/DMARC + `llm` **ไม่ถูกแตะ** |
| เอกสาร | 27 ไฟล์ |

`willpower-opencode` ตั้ง webhook ไม่ผ่านรอบแรก (`Invalid webhook endpoint URL`)
แต่ `PUT` ซ้ำผ่านทันที — น่าจะโดน rate limit หลังยิงรวด 13 ครั้ง
**ยังไม่ได้ใส่ retry ให้เครื่องมือ**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTaqjACHoPorgseAtw6Nvc