### PR TITLE
fix(deploy): adkcode ไม่เปิด route UI ให้โดยค่าเริ่มต้น

### DIFF
--- a/botforge-deploy
+++ b/botforge-deploy
@@ -419,10 +419,21 @@ get_server_port() {
 # V2 มีเฉพาะ opencode กับ adkcode ที่มี container แยก
 # ส่วน codex spawn app-server เป็น child process และ claude เรียก SDK ใน process เดียวกัน
 engine_has_ui() {
+    # ⚠️ adkcode ไม่เปิด route UI ให้โดยค่าเริ่มต้น — auth ของมันกันไม่ได้
+    #    `server/api.py:85` ข้าม auth ให้ `/dev-ui*` เสมอ ส่วน API ที่ UI เรียก
+    #    (`/list-apps`, `/run_sse`, `/apps/...`) อยู่ root level จึงโดน 401
+    #    ตั้ง API_PASSWORD แล้วได้ผลคือ "หน้ายังเปิดโล่ง แต่ UI ใช้งานไม่ได้"
+    #    ซึ่งแย่กว่าทั้งสองทาง — ตรวจกับ legal-services-server ตัวจริงเมื่อ 2026-08-24
+    #
+    #    ถ้าจะเปิดจริง ๆ ต้องกันที่ขอบ (Cloudflare Access / basicauth ที่ reverse proxy)
+    #    แล้วค่อยตั้ง BOTFORGE_EXPOSE_ADKCODE_UI=1
+    case "${1#v2:}" in
+        adkcode) [[ "${BOTFORGE_EXPOSE_ADKCODE_UI:-0}" == "1" ]] && return 0 || return 1 ;;
+    esac
     case "$1" in
-        v2:opencode|v2:adkcode) return 0 ;;   # V2 ที่มี container ของ engine
-        v2:*)                   return 1 ;;   # V2 ที่เหลือไม่มี
-        *)                      return 0 ;;   # V1 ทุกตัวมี service server
+        v2:opencode) return 0 ;;   # V2 ที่มี container ของ engine
+        v2:*)        return 1 ;;   # V2 ที่เหลือไม่มี
+        *)           return 0 ;;   # V1 ที่เหลือมี service server
     esac
 }
 
@@ -515,7 +526,11 @@ cmd_tunnel_setup() {
             ingress_rules+="{\"hostname\":\"$host_server\",\"service\":\"http://${name}-server:${server_port}\"},"
             echo "    $host_server → http://${name}-server:${server_port}   (UI ของ engine)"
         else
-            echo "    (ข้าม route UI — $engine ไม่มี container ของ engine แยก)"
+            if [[ "${engine#v2:}" == "adkcode" ]]; then
+                echo "    (ข้าม route UI — ADK dev UI กัน auth ไม่ได้ · BOTFORGE_EXPOSE_ADKCODE_UI=1 ถ้าจะเปิด)"
+            else
+                echo "    (ข้าม route UI — $engine ไม่มี container ของ engine แยก)"
+            fi
         fi
 
         # ⚠️ จังหวะนี้คือจังหวะที่ UI ถูกเปิดออกอินเทอร์เน็ตจริง — เตือนถ้ายังไม่มีรหัส

--- a/docs/architecture/open-items.md
+++ b/docs/architecture/open-items.md
@@ -194,6 +194,23 @@ claude-code · copilot-cli ไม่มีปัญหานี้ — server �
 Cloudflare Access หน้า `<name>-server.<domain>` เพราะ LINE bot ไม่ได้วิ่งผ่าน tunnel
 (คุยกันในเครือข่าย docker) จึงไม่กระทบ **ยังไม่ได้ทำและยังไม่ได้ตรวจว่า plan รองรับ**
 
+## ✅ adkcode ไม่เปิด route UI ให้แล้วโดยค่าเริ่มต้น 2026-08-24
+
+`engine_has_ui()` ตอบ **ไม่** สำหรับ `adkcode` ทั้ง V1 และ V2 — เปิดได้ด้วย
+`BOTFORGE_EXPOSE_ADKCODE_UI=1` เมื่อกันที่ขอบไว้แล้ว (Cloudflare Access / basicauth)
+
+เหตุผล: ADK dev UI กัน auth ไม่ได้ `server/api.py:85` ข้าม auth ให้ `/dev-ui*` เสมอ
+ส่วน API ที่ UI เรียก (`/list-apps`, `/run_sse`, `/apps/...`) อยู่ root level จึงโดน 401
+ตั้ง `API_PASSWORD` แล้วได้ผลคือ **หน้ายังเปิดโล่ง แต่ UI ใช้งานไม่ได้** แย่กว่าทั้งสองทาง
+
+ลบของที่ `tunnel setup all` สร้างไว้แล้ว: ingress ของ `legal-adkcode` · `legal-services`
+เหลือ route เดียว และลบ DNS `legal-adkcode-server` · `legal-services-server`
+ยืนยันจาก Cloudflare API: 14 เดิม + 28 สร้าง − 2 ลบ = **40 record ตรงเป๊ะ** ·
+record เดิมของโซน (เว็บ · MX×5 · SPF/DKIM/DMARC · `llm`) ครบทุกตัว ·
+hostname `-server` เหลือ 12 = opencode 9 + claude/copilot 3
+
+---
+
 ## ✅ legal-services เคยเปิดโล่ง — ปิด route ที่ Caddy แล้ว 2026-08-24
 
 ยิงจากภายนอกเมื่อ 2026-08-24:


### PR DESCRIPTION
เมื่อวานปิด route นี้ที่ Caddy ไปแล้ว แต่ `tunnel setup all` วันนี้ **สร้างทางกลับมาให้ใหม่**
(`legal-services-server.sumana.org`) — ลบทีละครั้งไม่พอ เพราะ `tunnel setup` รอบหน้าจะสร้างคืนอีก
ต้องแก้ที่ `engine_has_ui`

## ทำไม adkcode ต้องเป็นข้อยกเว้น

ADK dev UI **กัน auth ไม่ได้**:

| path | auth |
|---|---|
| `/dev-ui*` | `api.py:85` ข้ามให้เสมอ → เปิดโล่ง |
| `/list-apps` · `/run_sse` · `/apps/...` | root level → 401 เมื่อเปิด auth |

ตั้ง `API_PASSWORD` แล้วได้ผลคือ **หน้ายังเปิดโล่ง แต่ UI ใช้งานไม่ได้** — แย่กว่าทั้งสองทาง
และ ADK dev UI ไม่มีช่องให้กรอกรหัส เบราว์เซอร์ส่ง `Authorization` เองไม่ได้

## ที่แก้

`engine_has_ui()` ตอบ **ไม่** สำหรับ `adkcode` ทั้ง V1 และ V2
เปิดได้ด้วย `BOTFORGE_EXPOSE_ADKCODE_UI=1` เมื่อกันที่ขอบไว้แล้ว (Cloudflare Access / basicauth)

| engine | default | `EXPOSE=1` |
|---|:-:|:-:|
| `opencode` · `claude-code` · `copilot-cli` · `codex` · `gocode` · `v2:opencode` | มี | มี |
| `adkcode` · `v2:adkcode` | **ไม่มี** | มี |
| `v2:claude` · `v2:codex` | ไม่มี | ไม่มี |

## ลบของที่สร้างไปแล้ว

ingress ของ `legal-adkcode` + `legal-services` เหลือ route เดียว · ลบ DNS `-server` ทั้งสอง

ยืนยันจาก Cloudflare API:
- **14 เดิม + 28 สร้าง − 2 ลบ = 40 record ตรงเป๊ะ**
- record เดิมของโซนครบทุกตัว (เว็บ · `www` · MX×5 · SPF/DKIM/DMARC · `llm` · `llm-api` · `_domainconnect` · google verify)
- hostname `-server` เหลือ 12 = opencode 9 + claude/copilot 3
- ยิงจริง `legal-services-server.sumana.org/dev-ui/` → **530** ไม่มี ingress ให้ route ไป

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTaqjACHoPorgseAtw6Nvc