### PR TITLE
docs: วิธีล็อกอิน UI ของ opencode + ผลการยก nst-opencode ขึ้นเครื่องใหม่

### DIFF
--- a/apps/line-bot/README.md
+++ b/apps/line-bot/README.md
@@ -131,6 +131,18 @@ engine ที่มี UI:
 > ถ้าตั้งชื่อ container เป็น `<prefix>-opencode` route UI จะ 502
 > (ยืนยันแล้วด้วย stack จริง: `http://uitest-server:4096/` → `200 text/html` title `OpenCode`)
 
+### ล็อกอิน UI ของ opencode
+
+**Basic auth · username คือ `opencode`** (ตายตัว) · password คือ `OPENCODE_PASSWORD`
+
+```bash
+curl -u "opencode:$OPENCODE_PASSWORD" https://<name>-server.<domain>/global/health
+```
+
+เบราว์เซอร์จะขึ้นกล่องให้กรอก — ใส่ `opencode` เป็นชื่อผู้ใช้
+ทั้ง V1 (`src/index.ts:61`) และ V2 (`adapter-opencode/src/client.ts:27`) ประกอบ header
+แบบเดียวกัน ใส่ username อื่นจะได้ 401
+
 > ⚠️ **auth ของ server เป็น opt-in และค่าว่าง = ไม่ติดตั้ง middleware เลย**
 > ตรวจแล้วกับ container จริง — `/global/health` ตอบ 200 โดยไม่ต้อง auth
 >

--- a/docs/architecture/domain-change.md
+++ b/docs/architecture/domain-change.md
@@ -155,3 +155,26 @@ tunnel ชื่อ `icbserv-ssh` ในบัญชีเดียวกัน�
 
 `legal-services.eformservice.com` ยังเปิดอยู่ตามเดิม และ LINE ยังใช้
 `legal.thaidirection.com/line/webhook` — ทั้งคู่ไม่ผูกกับ `sumana.*` การย้าย domain ไม่กระทบ
+
+---
+
+# ผลการย้ายจริง 2026-08-24
+
+ย้าย `sumana.online` → `sumana.org` สำเร็จ · 13 webhook ย้ายแล้ว ·
+`legal-services` ถูกข้ามอัตโนมัติตามที่ออกแบบไว้ · DNS 40 record (14 เดิม + 28 − 2)
+
+## bot ตัวแรกที่ยกขึ้นเครื่องนี้ — `nst-opencode`
+
+```
+docker: server + line-bot + tunnel      ✅ ขึ้นครบ
+tunnel → Cloudflare                      ✅ 3 connection (sin07/sin13/sin17)
+bot ดึง userId จาก LINE                  ✅ credential ใช้ได้
+https://nst-opencode.sumana.org/         200
+  └ POST /webhook ลายเซ็นปลอม            403  ← signature validation ทำงาน
+https://nst-opencode-server.sumana.org/  401 เมื่อไม่ใส่รหัส · 200 เมื่อใส่ถูก
+LINE POST /webhook/test                  {"success": true, "statusCode": 200}
+```
+
+**UI ของ opencode ล็อกอินด้วย Basic auth · username `opencode` ตายตัว**
+password คือ `OPENCODE_PASSWORD` — ใส่ username อื่นได้ 401
+(V1 `src/index.ts:61` · V2 `adapter-opencode/src/client.ts:27` ประกอบเหมือนกัน)


### PR DESCRIPTION
## opencode UI ล็อกอินยังไง

**Basic auth · username เป็น `opencode` ตายตัว** password คือ `OPENCODE_PASSWORD`

เสียเวลาไปรอบหนึ่งเพราะลอง `Bearer` และ Basic ที่ username อื่น — ได้ 401 ทั้งคู่
V1 (`src/index.ts:61`) และ V2 (`adapter-opencode/src/client.ts:27`) ประกอบ header เหมือนกัน

## `nst-opencode` — bot ตัวแรกบน domain ใหม่ ผ่านครบ

| ด่าน | ผล |
|---|---|
| container `server` + `line-bot` + `tunnel` | ✅ ขึ้นครบ |
| tunnel → Cloudflare | ✅ 3 connection (sin07 / sin13 / sin17) |
| bot ดึง userId จาก LINE | ✅ credential ใช้ได้ |
| `https://nst-opencode.sumana.org/` | 200 |
| `POST /webhook` ลายเซ็นปลอม | **403** signature validation ทำงาน |
| `https://nst-opencode-server.sumana.org/` ไม่ใส่รหัส | **401** |
| ใส่รหัสถูก | **200** `<title>OpenCode` |
| ใส่รหัสผิด | **401** |
| LINE `POST /webhook/test` | **`{"success": true, "statusCode": 200}`** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTaqjACHoPorgseAtw6Nvc