### PR TITLE
feat: เพิ่ม engine hermes — Hermes Agent ที่เป็นเจ้าของ LINE channel เอง

### DIFF
--- a/botforge
+++ b/botforge
@@ -96,6 +96,7 @@ cmd_new() {
     echo "    7) codex       — OpenAI Codex CLI (agentic, ChatGPT login or API key)"
     echo "    8) copilot-cli — GitHub Copilot SDK (Claude/GPT-5/o4-mini, GitHub OAuth)"
     echo "    9) codex-appserver — OpenAI Codex App Server (WebSocket JSON-RPC, persistent)"
+    echo "   10) hermes      — Hermes Agent (มี LINE adapter ในตัว · ไม่ใช้ line-bot ของ botforge)"
     read -rp "  Select [1]: " engine_choice
     engine_choice="${engine_choice:-1}"
 
@@ -110,6 +111,7 @@ cmd_new() {
         7) engine="codex"; bot_template="bot-service-codex" ;;
         8) engine="copilot-cli"; bot_template="bot-service-copilot-cli" ;;
         9) engine="codex-appserver"; bot_template="bot-service-codex-appserver" ;;
+        10) engine="hermes"; bot_template="bot-service-hermes" ;;
         0) engine="v2"; bot_template="bot-service-v2" ;;
     esac
 
@@ -163,7 +165,13 @@ cmd_new() {
     echo "    Engine:     $engine"
     echo "    GitHub:     $github_org/$project_name"
     echo "    Domain:     $domain"
-    echo "    Containers: ${container_prefix}-server, ${container_prefix}-line-bot, ${container_prefix}-tunnel"
+    # hermes ไม่มี container `-server` — ทั้ง service คือตัว hermes เอง
+    # (มี LINE adapter ในตัว จึงไม่มี engine แยกให้ bot คุยด้วย)
+    if [[ "$engine" == "hermes" ]]; then
+        echo "    Containers: ${container_prefix}-line-bot (hermes), ${container_prefix}-tunnel"
+    else
+        echo "    Containers: ${container_prefix}-server, ${container_prefix}-line-bot, ${container_prefix}-tunnel"
+    fi
     echo ""
 
     read -rp "  Proceed? [Y/n]: " confirm
@@ -257,8 +265,16 @@ cmd_new() {
     if [[ -n "$env_generated" ]]; then
         echo ""
         echo -e "  ${GREEN}${BOLD}$env_generated สุ่มให้แล้ว${NC} (${BOTFORGE_PASSWORD_LEN} chars, in .env)"
-        echo -e "  ${BOLD}Why:${NC} the engine UI is exposed at https://${project_name}-server.${domain#*.}"
-        echo "       through the tunnel, and auth is off when this value is empty."
+        if [[ "$engine" == "hermes" ]]; then
+            # dashboard ของ hermes ปิดไว้โดย default และ tunnel ไม่เปิด route ให้
+            # (engine_has_ui คืน false) — สุ่มไว้ล่วงหน้าเผื่อเปิดทีหลัง
+            echo -e "  ${BOLD}Why:${NC} Hermes dashboard ปิดอยู่ (HERMES_DASHBOARD=0) และ tunnel"
+            echo "       ยังไม่เปิด route ให้ — สุ่มไว้ก่อนเผื่อเปิดทีหลัง จะได้ไม่เปิดโล่ง"
+            echo "       เปิดจริง: HERMES_DASHBOARD=1 + BOTFORGE_EXPOSE_HERMES_UI=1 แล้ว tunnel setup ใหม่"
+        else
+            echo -e "  ${BOLD}Why:${NC} the engine UI is exposed at https://${project_name}-server.${domain#*.}"
+            echo "       through the tunnel, and auth is off when this value is empty."
+        fi
     fi
     echo ""
     echo -e "  ${BOLD}Webhook URL:${NC} https://${domain}/webhook"
@@ -361,6 +377,7 @@ engine_to_template() {
         qwen-code)   echo "bot-service-qwen-code" ;;
         codex)       echo "bot-service-codex" ;;
         codex-appserver) echo "bot-service-codex-appserver" ;;
+        hermes)      echo "bot-service-hermes" ;;
         copilot-cli) echo "bot-service-copilot-cli" ;;
         *)           echo "" ;;
     esac

--- a/botforge-deploy
+++ b/botforge-deploy
@@ -433,9 +433,12 @@ engine_has_ui() {
     #    แล้วค่อยตั้ง BOTFORGE_EXPOSE_ADKCODE_UI=1
     case "${1#v2:}" in
         adkcode) [[ "${BOTFORGE_EXPOSE_ADKCODE_UI:-0}" == "1" ]] && return 0 || return 1 ;;
-        # hermes ไม่มี container `<name>-server` — ทั้ง service คือตัว hermes เอง
-        # dashboard ปิดไว้โดย default (HERMES_DASHBOARD=0) ใส่ route ไปก็ 502
-        # จะเปิดต้องตั้ง HERMES_DASHBOARD=1 + DASHBOARD_PASS แล้ว BOTFORGE_EXPOSE_HERMES_UI=1
+        # hermes ไม่มี container `<name>-server` แยก — ทั้ง service คือตัว hermes เอง
+        # เทมเพลตจึงใส่ network alias `<prefix>-server` ให้ route ชี้ถูก
+        # ปิดไว้โดย default เพราะ dashboard เองก็ปิด (HERMES_DASHBOARD=0) และมันแก้
+        # env/config ได้จากหน้าเว็บ (เห็น LINE token / API key) — เปิดเมื่อจงใจเท่านั้น
+        # เปิด: HERMES_DASHBOARD=1 + DASHBOARD_PASS + HERMES_DASHBOARD_PORT=4096
+        #       แล้ว BOTFORGE_EXPOSE_HERMES_UI=1 ./botforge-deploy tunnel setup <name>
         hermes)  [[ "${BOTFORGE_EXPOSE_HERMES_UI:-0}" == "1" ]] && return 0 || return 1 ;;
     esac
     case "$1" in

--- a/botforge-deploy
+++ b/botforge-deploy
@@ -73,6 +73,9 @@ detect_engine() {
         echo "adkcode"
     elif [[ -f "$dir/server/go.mod" ]]; then
         echo "gocode"
+    elif [[ -f "$dir/config/config.yaml.tmpl" ]]; then
+        # hermes ไม่มี server แยกและไม่มี src/ — ทั้ง service คือ hermes เอง
+        echo "hermes"
     elif [[ -f "$dir/opencode.json" ]]; then
         echo "opencode"
     elif grep -q "GEMINI_MODEL" "$dir/docker-compose.yml" 2>/dev/null; then
@@ -406,6 +409,7 @@ get_server_port() {
     local engine="${1#v2:}"          # v2:adkcode → adkcode
     case "$engine" in
         adkcode) echo "8000" ;;
+        hermes)  echo "9119" ;;   # dashboard ของ Hermes (ไม่ใช่ 4096)
         *)       echo "4096" ;;
     esac
 }
@@ -429,6 +433,10 @@ engine_has_ui() {
     #    แล้วค่อยตั้ง BOTFORGE_EXPOSE_ADKCODE_UI=1
     case "${1#v2:}" in
         adkcode) [[ "${BOTFORGE_EXPOSE_ADKCODE_UI:-0}" == "1" ]] && return 0 || return 1 ;;
+        # hermes ไม่มี container `<name>-server` — ทั้ง service คือตัว hermes เอง
+        # dashboard ปิดไว้โดย default (HERMES_DASHBOARD=0) ใส่ route ไปก็ 502
+        # จะเปิดต้องตั้ง HERMES_DASHBOARD=1 + DASHBOARD_PASS แล้ว BOTFORGE_EXPOSE_HERMES_UI=1
+        hermes)  [[ "${BOTFORGE_EXPOSE_HERMES_UI:-0}" == "1" ]] && return 0 || return 1 ;;
     esac
     case "$1" in
         v2:opencode) return 0 ;;   # V2 ที่มี container ของ engine

--- a/lib/secret.sh
+++ b/lib/secret.sh
@@ -92,6 +92,8 @@ secret_key_for() {
             # V1 ทุก engine มี service `server` และ tunnel เปิด route ให้ทุกตัว
             case "$name" in
                 opencode) echo "OPENCODE_PASSWORD" ;;
+                # hermes ไม่มี container server — รหัสที่มีคือ basic auth ของ dashboard
+                hermes)   echo "DASHBOARD_PASS" ;;
                 *)        echo "API_PASSWORD" ;;
             esac ;;
         v2)

--- a/templates/bot-service-hermes/.env.example
+++ b/templates/bot-service-hermes/.env.example
@@ -1,0 +1,93 @@
+# คัดลอกเป็น .env แล้วเติมค่า — botforge new สร้าง .env ให้อัตโนมัติแล้ว
+#
+# ⚠️ ห้ามเขียนคอมเมนต์ต่อท้ายบรรทัดค่า — docker compose ไม่ตัด inline comment
+#    ตัวคอมเมนต์จะกลายเป็นส่วนหนึ่งของค่าจริง (เคยทำให้ allowlist เพี้ยนมาแล้ว)
+#    เขียนคอมเมนต์ไว้บรรทัดบนแทน
+
+# ===================== LINE Messaging API ==============================
+# https://developers.line.biz/console/ → channel ของ Messaging API
+#   - Messaging API → Channel access token (long-lived) → Issue
+#   - Basic settings → Channel secret
+#   - Webhook URL → https://{{DOMAIN}}/webhook  แล้วกด Verify
+#   - Use webhook → เปิด
+#   - Auto-reply / Greeting messages → ปิด (ไม่งั้นชนกับบอท)
+#   - Allow bot to join group chats → เปิด  ← ขาดข้อนี้แล้วใช้ในกลุ่มไม่ได้
+LINE_CHANNEL_ACCESS_TOKEN=your-channel-access-token
+LINE_CHANNEL_SECRET=your-channel-secret
+LINE_OA_URL=https://line.me/ti/p/~your-oa
+
+# --- allowlist 3 ชั้น (คั่นด้วย comma) ---------------------------------
+# คนละลิสต์กันจริง ๆ: ใส่ user ไม่ได้ทำให้คุยใน group ได้ ต้องใส่ group id ด้วย
+# วิธีหา id: ตั้ง LINE_ALLOW_ALL_USERS=true ชั่วคราว ทักบอท แล้วดู
+#   docker compose logs -f line-bot | grep -i "line:"
+# U0123... = แชทส่วนตัว
+LINE_ALLOWED_USERS=
+# C0123... = กลุ่ม
+LINE_ALLOWED_GROUPS=
+# R0123... = ห้องแบบหลายคนที่ไม่ใช่กลุ่ม
+LINE_ALLOWED_ROOMS=
+
+# true = ใครก็คุยกับบอทได้ ปิด allowlist ทั้ง 3 ชั้น
+# ใช้ตอนเก็บ id รอบแรกเท่านั้น แล้วปิดกลับเป็น false
+LINE_ALLOW_ALL_USERS=false
+
+# ปลายทางของ cron / แจ้งเตือนที่บอทเป็นฝ่ายเริ่มเอง (ว่างได้)
+LINE_HOME_CHANNEL=
+
+# base URL https ที่ชี้กลับมาที่ container นี้ — ใช้ตอนส่งรูป/ไฟล์กลับเข้า LINE
+LINE_PUBLIC_URL=https://{{DOMAIN}}
+
+# reply token ของ LINE อายุ ~60s เกินกี่วินาทีถึงยิงปุ่ม postback ให้กดรับคำตอบ
+# 0 = ปิด แล้วไปใช้ Push API แทนทุกครั้ง (Push กินโควตาข้อความของ OA)
+LINE_SLOW_RESPONSE_THRESHOLD=45
+
+# ===================== Model (LiteLLM gateway) =========================
+# ต้องมี LiteLLM รันอยู่บนเครื่องนี้แล้ว และอยู่บน network llm-clients
+#   docker network create llm-clients
+#   docker network connect llm-clients llm-litellm
+#
+# ออก virtual key แยกใบต่อ project — อย่าใช้ LITELLM_MASTER_KEY
+# master key เป็น admin ของทั้ง gateway (ออก/เพิกถอน key คนอื่น, ข้าม budget)
+#   ./scripts/gen-key.sh --alias {{PROJECT_NAME}}     (ที่ฝั่ง LiteLLM)
+LITELLM_KEY=
+LITELLM_BASE_URL=http://llm-litellm:4000/v1
+
+# main model — ต้องผ่าน ./scripts/probe-litellm.sh และ ./scripts/probe-thai.sh
+HERMES_MODEL=oc/minimax-m3
+HERMES_MAX_TURNS=60
+
+# ===================== Cloudflare Tunnel ===============================
+# botforge-deploy tunnel setup {{PROJECT_NAME}}   จะเติมให้
+CLOUDFLARE_TUNNEL_TOKEN=your-tunnel-token
+
+# ===================== Hermes ==========================================
+# pin version เสมอ ห้ามใช้ latest
+HERMES_VERSION=v2026.8.3
+CONTAINER_PREFIX={{CONTAINER_PREFIX}}
+
+# image รันด้วย user hermes UID 10000 — ตั้งให้ตรง `id -u` / `id -g` ของ owner ./data
+PUID=1001
+PGID=1001
+
+# 3000 = ที่ tunnel ของ botforge ชี้มา ห้ามเปลี่ยนถ้าไม่แก้ ingress ด้วย
+LINE_PORT=3000
+# ต้องตรงกับ platforms.line.extra.webhook_path ใน config/config.yaml.tmpl
+LINE_WEBHOOK_PATH=/webhook
+
+# ===================== Dashboard (optional) ============================
+# 1 = เปิด web dashboard ที่ :9119
+# ถ้าเปิดและจะให้เข้าจากเน็ต ต้องเพิ่ม route ใน tunnel เอง (ชี้ :9119 ไม่ใช่ :4096)
+HERMES_DASHBOARD=0
+DASHBOARD_USER=hermes
+DASHBOARD_PASS=
+
+# ===================== Resource ========================================
+MEM_LIMIT=4G
+CPU_LIMIT=2.0
+# 1g สำหรับ browser tool — ถ้าปิด toolset browser แล้วลดเหลือ 64m ได้
+SHM_SIZE=1g
+TZ=Asia/Bangkok
+
+# กลุ่มที่ยกให้ "ทุกคนในกลุ่ม" ใช้บอทได้ (ไม่ต้องอยู่ใน LINE_ALLOWED_USERS)
+# ว่าง = ใช้ค่าเดียวกับ LINE_ALLOWED_GROUPS  ใส่ "*" = ทุกกลุ่มที่ผ่าน LINE_ALLOWED_GROUPS
+LINE_GROUP_ALLOWED_CHATS=

--- a/templates/bot-service-hermes/.env.example
+++ b/templates/bot-service-hermes/.env.example
@@ -80,6 +80,10 @@ LINE_WEBHOOK_PATH=/webhook
 HERMES_DASHBOARD=0
 DASHBOARD_USER=hermes
 DASHBOARD_PASS=
+# port ของ dashboard  ค่า default ของ Hermes = 9119
+# ถ้าจะเปิดผ่าน tunnel ของ botforge ให้ตั้งเป็น 4096 (port ที่ ingress ชี้ไว้)
+# แล้วเปิด route ด้วย  BOTFORGE_EXPOSE_HERMES_UI=1 ./botforge-deploy tunnel setup {{PROJECT_NAME}}
+HERMES_DASHBOARD_PORT=9119
 
 # ===================== Resource ========================================
 MEM_LIMIT=4G

--- a/templates/bot-service-hermes/.gitignore
+++ b/templates/bot-service-hermes/.gitignore
@@ -1,0 +1,5 @@
+.env
+data/
+results/
+*.bak
+*.log

--- a/templates/bot-service-hermes/README.md
+++ b/templates/bot-service-hermes/README.md
@@ -1,0 +1,162 @@
+# {{PROJECT_NAME}} — Hermes Agent × LINE OA
+
+LINE bot ที่ขับด้วย [Hermes Agent](https://hub.docker.com/r/nousresearch/hermes-agent)
+โดยรับโมเดลจาก LiteLLM gateway — คุยได้ทั้งแชทส่วนตัวและในกลุ่ม
+
+## เทมเพลตนี้ต่างจาก engine ตัวอื่นของ botforge
+
+```
+engine อื่น:  LINE ──► botforge line-bot ──► engine server
+              (bun + @line/bot-sdk ~1,300 บรรทัด)
+
+hermes:       LINE ──► hermes  (มี LINE adapter ในตัว)
+```
+
+**Hermes เป็นเจ้าของ LINE channel เอง** — `plugins/platforms/line/adapter.py`
+1,758 บรรทัดที่มาพร้อม image ทำให้แล้วทั้ง:
+
+| ความสามารถ | |
+|---|---|
+| แชทส่วนตัว / กลุ่ม (C…) / ห้อง (R…) | ✅ |
+| ตรวจลายเซ็น HMAC-SHA256 | ✅ |
+| กัน webhook ส่งซ้ำ (`webhookEventId`) | ✅ |
+| กันบอทตอบตัวเอง | ✅ |
+| allowlist 3 ชั้น (user/group/room) | ✅ |
+| reply token ก่อน แล้วค่อย Push | ✅ ประหยัดโควตาข้อความ OA |
+| ตอบช้า → ปุ่ม postback ขอคำตอบด้วย token ใหม่ (ฟรี) | ✅ |
+| ตัดข้อความยาวเป็นหลาย bubble (4,500 ตัว / ≤5 ต่อ call) | ✅ |
+| รับรูป/เสียง/วิดีโอ/ไฟล์ | ✅ |
+
+**เทมเพลตนี้จึงไม่มี `src/` ไม่มี `Dockerfile` ไม่มี `package.json`** — มีแต่ config
+
+> ⚠️ **ไม่มีเงื่อนไข @mention** — ในกลุ่มที่ผ่าน allowlist บอทตอบ **ทุกข้อความ**
+> (adapter ไม่มี logic mention เลย ต่างจาก Mattermost ที่มี `MATTERMOST_REQUIRE_MENTION`)
+> กลุ่มที่คนคุยกันเยอะจะเผาโควตาโมเดลเร็วมาก — ตั้ง `LINE_ALLOWED_GROUPS` ให้แคบไว้ก่อน
+
+## เริ่มใช้
+
+ต้องมี **LiteLLM gateway** รันอยู่บนเครื่องนี้ และอยู่บน network `llm-clients`:
+
+```bash
+docker network create llm-clients
+docker network connect llm-clients llm-litellm
+```
+
+แล้วออก **virtual key แยกใบ** ให้ project นี้ (อย่าใช้ master key — มันเป็น admin
+ของทั้ง gateway: ออก/เพิกถอน key คนอื่นได้ ข้าม budget ได้) เอาไปใส่ `LITELLM_KEY` ใน `.env`
+
+```bash
+./scripts/init.sh            # เตรียม data/ + gen config + ตรวจทาง LiteLLM
+docker compose up -d
+docker compose logs -f line-bot
+./scripts/trim-skills.sh     # ตัด bundled skills 71 → 4 (ลด token ต่อ call)
+```
+
+### ตั้ง LINE channel
+
+[LINE Developers Console](https://developers.line.biz/console/) → Messaging API channel
+
+- *Channel access token (long-lived)* → `LINE_CHANNEL_ACCESS_TOKEN`
+- *Channel secret* (Basic settings) → `LINE_CHANNEL_SECRET`
+- *Webhook URL* → `https://{{DOMAIN}}/webhook` → **Verify**
+- *Use webhook* → เปิด
+- *Auto-reply* / *Greeting messages* → **ปิด** (ไม่งั้นชนกับบอท)
+- *Allow bot to join group chats* → **เปิด** ← ขาดข้อนี้แล้วใช้ในกลุ่มไม่ได้
+
+### เก็บ id แล้วปิด allowlist
+
+```bash
+# รอบแรก: เปิดรับทุกคนชั่วคราว
+sed -i 's/^LINE_ALLOW_ALL_USERS=.*/LINE_ALLOW_ALL_USERS=true/' .env
+docker compose up -d --force-recreate line-bot
+docker compose logs -f line-bot | grep -i "line:"     # ทักบอท แล้วดู U… / C…
+
+# ใส่ id ที่ได้ลง LINE_ALLOWED_USERS / LINE_ALLOWED_GROUPS แล้วปิดกลับ
+sed -i 's/^LINE_ALLOW_ALL_USERS=.*/LINE_ALLOW_ALL_USERS=false/' .env
+docker compose up -d --force-recreate line-bot
+```
+
+> 🔴 **ห้ามเขียนคอมเมนต์ต่อท้ายบรรทัดค่าใน `.env`** — docker compose ไม่ตัด
+> inline comment ตัวคอมเมนต์จะกลายเป็นส่วนหนึ่งของค่าและเข้าไปอยู่ใน allowlist จริง ๆ
+
+### ทดสอบโดยไม่ต้องมี LINE จริง
+
+```bash
+./scripts/smoke-webhook.sh                  # แชทส่วนตัว
+./scripts/smoke-webhook.sh --group          # ในกลุ่ม
+./scripts/smoke-webhook.sh --bad-sig        # ต้องได้ 401
+./scripts/smoke-webhook.sh --id Ufffffff…   # ทดสอบว่า allowlist กันคนนอกจริง
+```
+
+ยิง webhook ที่ **เซ็นด้วย channel secret จริง** พิสูจน์ได้ทั้งเส้น
+ลายเซ็น → allowlist → session → โมเดล (ส่งกลับ LINE ไม่ได้เพราะ reply token ปลอม
+— คำตอบไปโผล่ใน `docker compose logs line-bot`)
+
+## โมเดล
+
+Hermes กิน **~16K tokens ต่อ 1 call** (system prompt + tool schemas) และวิ่งด้วย
+tool loop ล้วน ๆ โมเดลจึงต้องผ่าน 3 ข้อ ไม่ใช่แค่ "ตอบได้":
+
+1. คืน `tool_calls` เป็น field จริง ไม่ใช่ `<tool_call>` ปนใน `content`
+2. รับ prompt ~14K tokens ได้ ไม่เด้ง 429/413
+3. **อยู่กับภาษาที่ผู้ใช้ใช้** ตอนบริบทเต็มไปด้วยอังกฤษ
+
+```bash
+./scripts/probe-litellm.sh    # ข้อ 1-2 (ยิง API ตรง)
+./scripts/probe-thai.sh       # ข้อ 3 (ยิงผ่าน Hermes จริง) ← ข้อนี้ยิง API ตรงวัดไม่ได้
+```
+
+สลับโมเดลจากในแชท: `/fast` `/big` `/nim` `/mistral` หรือ `/model <ชื่อ>`
+
+> 🔴 ประกาศ provider เป็น **`custom_providers:` (list)** ไม่ใช่ `providers:` (dict)
+> ถ้าใช้ dict Hermes จะนับ provider ตัวเดียวเป็นสองตัว แล้ว `/model <ชื่อ>` จะ error
+> *"is declared by multiple configured providers"* ทุกครั้ง
+
+## ลด token ต่อ call
+
+```bash
+./scripts/trim-skills.sh                    # 71 → 4 skills (ตาม config/skills-keep.txt)
+./scripts/trim-skills.sh --list-available   # ดูรายชื่อทั้งหมด
+./scripts/trim-skills.sh --restore          # เอากลับมาทั้งหมด
+docker exec {{CONTAINER_PREFIX}}-line-bot hermes prompt-size --platform line
+```
+
+`platform_toolsets` ใน `config/config.yaml.tmpl` เป็น **allowlist** ของ toolset
+(ตัวที่ไม่อยู่ในลิสต์ = ปิด) — ตัด `browser` `delegation` `tts` `vision` ไว้แล้ว
+
+## พฤติกรรมในกลุ่ม
+
+`group_sessions_per_user: false` (ตั้งไว้ใน template) = **ทั้งกลุ่มใช้ session เดียว**
+บอทเห็นบทสนทนาต่อเนื่องของทุกคน เหมาะกับ "ผู้ช่วยประจำกลุ่ม"
+
+⚠️ ทุกคนในกลุ่มเห็นบริบทเดียวกัน **อย่าเอาข้อมูลลับเข้ากลุ่ม**
+ถ้าต้องการแยกรายคนให้ตั้งเป็น `true` (เป็น default ของ Hermes เอง)
+
+## ความเสี่ยงที่ต้องดู
+
+| ความเสี่ยง | ทางรับมือ |
+|---|---|
+| **Hermes รันคำสั่งใน container ได้จริง** | allowlist แคบ + ไม่ mount อะไรเกินจำเป็น |
+| ไม่มี @mention ในกลุ่ม → เผาโควตา | `LINE_ALLOWED_GROUPS` แคบไว้ก่อน |
+| ทุกคนในกลุ่มเห็นบริบทเดียวกัน | อย่าเอาข้อมูลลับเข้ากลุ่ม |
+| Push API กินโควตาข้อความ OA | `LINE_SLOW_RESPONSE_THRESHOLD=45` ใช้ปุ่ม postback แทน |
+| รันสอง gateway ชี้ `data/` เดียวกัน | ห้ามทำ — session/memory ไม่ concurrent-safe |
+
+## โครงไฟล์
+
+```
+bot-service/
+├── docker-compose.yml       # hermes (container {{CONTAINER_PREFIX}}-line-bot) + cloudflared
+├── .env.example / .env      # .env gitignore ไว้ chmod 600
+├── config/
+│   ├── config.yaml.tmpl     # template — ของจริงคือ data/config.yaml
+│   ├── SOUL.md              # persona (LINE ไม่ render markdown — SOUL.md สั่งไว้)
+│   └── skills-keep.txt      # skills ที่ให้ seed
+├── scripts/
+│   ├── init.sh              # เตรียม data/ + gen config + ตรวจทาง LiteLLM
+│   ├── probe-litellm.sh     # คัดโมเดล: tool calling + context
+│   ├── probe-thai.sh        # คัดโมเดล: อยู่กับภาษาไหม (ต้องยิงผ่าน Hermes จริง)
+│   ├── trim-skills.sh       # ตัด bundled skills
+│   └── smoke-webhook.sh     # ยิง webhook ที่เซ็นถูก
+└── data/                    # → /opt/data (gitignore) sessions/ memories/ skills/
+```

--- a/templates/bot-service-hermes/config/SOUL.md
+++ b/templates/bot-service-hermes/config/SOUL.md
@@ -1,0 +1,39 @@
+You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
+
+---
+
+## ช่องทางที่คุณอยู่: LINE
+
+คุณคุยกับผู้ใช้ผ่าน **LINE Official Account** ไม่ใช่ terminal และไม่ใช่หน้าเว็บ
+ข้อจำกัดของ LINE เปลี่ยนวิธีตอบของคุณ:
+
+**LINE แสดงผลเป็นข้อความล้วน ไม่ render markdown**
+`**ตัวหนา**` จะโผล่เป็นดอกจันจริง ๆ ตารางจะเละ code block ไม่มีกรอบ
+
+- ห้ามใช้ `**bold**` `*italic*` `# หัวข้อ` หรือตาราง markdown
+- รายการให้ใช้ `-` หรือ `1.` ขึ้นบรรทัดใหม่ธรรมดา
+- โค้ดสั้น ๆ พิมพ์เป็นบรรทัดเปล่า ๆ ได้ ถ้ายาวให้สรุปเป็นคำพูดแทน
+  แล้วบอกว่าถ้าอยากได้ไฟล์เต็มให้บอก
+
+**ตอบสั้น** — คนอ่านบนมือถือ ข้อความยาวเกิน 4,500 ตัวจะถูกหั่นเป็นหลายฟอง
+ตอบ 2-5 บรรทัดเป็นหลัก ถ้าเรื่องยาวให้สรุปก่อนแล้วถามว่าจะให้ลงรายละเอียดตรงไหน
+
+**ตอบเป็นภาษาเดียวกับที่ผู้ใช้ทัก** — ทักไทยตอบไทย ทักอังกฤษตอบอังกฤษ
+
+**งานที่ใช้เวลานานให้บอกก่อน** — reply token ของ LINE อายุประมาณ 1 นาที
+ถ้ารู้ว่างานจะนาน ให้ตอบสั้น ๆ ก่อนว่ากำลังทำอะไรอยู่ แล้วค่อยส่งผลตามไป
+
+## เวลาอยู่ในกลุ่ม
+
+ในกลุ่มคุณเห็นข้อความของทุกคนและใช้บริบทร่วมกันทั้งกลุ่ม
+
+- คุณ **ไม่ได้ถูกเรียกทุกครั้ง** ที่มีคนพิมพ์ — ถ้าเขาคุยกันเองอยู่
+  และข้อความนั้นไม่ได้ถามคุณ ให้ตอบสั้นที่สุดหรือไม่ต้องเพิ่มอะไร
+- อย่าสรุปทับบทสนทนาของคนอื่น อย่าแก้คนอื่นถ้าไม่ได้ถูกถาม
+- ทุกคนในกลุ่มเห็นสิ่งที่คุณพิมพ์ **อย่าเอาข้อมูลจากแชทส่วนตัวมาพูดในกลุ่ม**
+
+## เครื่องมือ
+
+คุณรันคำสั่งใน container ได้จริง — ในกลุ่มมีคนหลายคน ก่อนทำอะไรที่
+**ลบ เขียนทับ หรือแก้ของที่มีอยู่** ให้ถามยืนยันก่อนเสมอ
+อ่าน ค้น ดูสถานะ ทำได้เลยไม่ต้องถาม

--- a/templates/bot-service-hermes/config/config.yaml.tmpl
+++ b/templates/bot-service-hermes/config/config.yaml.tmpl
@@ -36,6 +36,20 @@ custom_providers:
   - name: litellm
     api: ${LITELLM_BASE_URL}
     key_env: LITELLM_KEY
+    # 🔴 ปิด fallback ฝั่ง gateway — ให้ Hermes คุม fallback ชั้นเดียว
+    #
+    # LiteLLM มี fallbacks ของตัวเอง (litellm/config.yaml) ถ้าเปิดทิ้งไว้จะเกิด
+    # fallback สองชั้นซ้อนกัน แล้ว gateway จะสลับโมเดลให้ "ก่อน" ที่ Hermes จะ
+    # ทันเห็น error → chain ที่เราเรียงข้าม quota_pool ไว้อย่างระวังไม่เคยได้ทำงาน
+    #
+    # และ gateway ไม่มีทางรู้ข้อจำกัดของเรา — เส้นที่เขาตั้งไว้พา hf/gpt-oss-120b
+    # ไป cb/gpt-oss-120b ซึ่ง "ค้างเงียบ" ที่ 32K ขณะที่ call จริงของเราแตะ 58K
+    # ส่วนเรื่องภาษา การ fallback ไปโมเดลที่ตอบจีนแย่กว่าปล่อยให้ error
+    #
+    # ตอนนี้โมเดลใน chain ของเราไม่มีตัวไหนที่ gateway ตั้ง fallback ไว้ให้
+    # แต่ตั้งไว้ล็อกไว้ก่อน จะได้ไม่พึ่งความบังเอิญว่าวันหนึ่งเขาจะไม่เพิ่ม
+    extra_body:
+      disable_fallbacks: true
     # false = เชื่อรายชื่อข้างล่าง ไม่ต้องไปถาม /models ตอน start
     # (gateway มี 72 โมเดล ส่วนใหญ่ Hermes ใช้ไม่ได้ — ดู docs/MODEL-PROBE.md)
     discover_models: false
@@ -62,7 +76,7 @@ model:
 # --- fallback ---------------------------------------------------------------
 # ต้องข้าม "ผู้ให้บริการ" ไม่ใช่แค่ข้ามชื่อโมเดล — โควตาผูกกับ provider
 # แต่ละ entry ต้องมีทั้ง provider และ model ไม่งั้นถูกข้ามเงียบ ๆ
-# LiteLLM มี fallbacks ของตัวเองอีกชั้นด้วย (litellm/config.yaml) — ชั้นนี้คือกันเหนียว
+# ชั้นนี้เป็น fallback ชั้นเดียวของระบบ — ฝั่ง gateway ปิดไปแล้วด้วย extra_body ข้างบน
 # เรียงให้ "ข้าม provider" ทุกชั้น และเอาตัวที่เร็วกว่าไว้ก่อน
 # ⚠️ อย่าเรียง mi/* ต่อกันเป็นชั้นแรก — โควตาผูกกับ provider ตายพร้อมกัน
 fallback_providers:

--- a/templates/bot-service-hermes/config/config.yaml.tmpl
+++ b/templates/bot-service-hermes/config/config.yaml.tmpl
@@ -59,7 +59,8 @@ custom_providers:
       # เวลาคือ "ต่อ turn จริงใน Hermes" ไม่ใช่ latency ของ call เดี่ยว
       - mi/ministral-14b       # Mistral    18s   ← main · 1B token/เดือน
       - mi/devstral-medium     # Mistral    51s   ใกล้เพดาน reply token ของ LINE (60s)
-      - or/ox-alpha            # OpenRouter ~19s  context 1M
+      - zen/hy3                # OpenCode Zen · reasoning · ไม่ต้องมี key · rpm-only
+                               # แทน or/ox-alpha ที่ตายถาวร 2026-08-27
       - cb/gpt-oss-120b        # Cerebras   เร็วสุด แต่ verified_max_prompt แค่ 13,655
                                #            และค้างเงียบที่ ~32K — เลือกเองได้ แต่ไม่อยู่ใน fallback
       - oc/minimax-m3          # Ollama Cloud 2.3s — ⚠️ โควตา "รายสัปดาห์" หมดทั้งตระกูล
@@ -67,6 +68,10 @@ custom_providers:
       - mi/large               # Mistral    90-180s ช้ามาก เก็บไว้เป็นตาข่ายท้าย ๆ
       # ตัดออก: oc/gpt-oss-120b (หลุดไปตอบจีน) · cf/llama-4-scout (ตอบอังกฤษ 1/3)
       #         mi/magistral-medium (146-227s/turn ช้าเกินใช้กับแชท)
+      #         or/ox-alpha (ตายถาวร 2026-08-27 — จบช่วง stealth testing ของ OpenRouter)
+      # ทดสอบแล้วแต่ไม่เอา: l7/llama-3.1-8b — ไทย 3/3 เร็ว 361ms ไม่ต้องมี key
+      #   แต่ตอบผิดแบบมั่นใจ ("ทะเลสีแดง") ซึ่งด้วยเหตุผลเดียวกับที่เราไม่ยอมให้
+      #   fallback ไปตัวที่ตอบผิดภาษา — คำตอบผิดที่ผู้ใช้เชื่อ แย่กว่า error
 
 # --- model ที่ใช้ ------------------------------------------------------------
 model:
@@ -80,7 +85,7 @@ model:
 # เรียงให้ "ข้าม provider" ทุกชั้น และเอาตัวที่เร็วกว่าไว้ก่อน
 # ⚠️ อย่าเรียง mi/* ต่อกันเป็นชั้นแรก — โควตาผูกกับ provider ตายพร้อมกัน
 fallback_providers:
-  - { provider: "custom:litellm", model: "or/ox-alpha" }         # OpenRouter  ~19s · max 31,833
+  - { provider: "custom:litellm", model: "zen/hy3" }             # OpenCode Zen · max 127,968 · ไทย 3/3
   - { provider: "custom:litellm", model: "mi/devstral-medium" }  # Mistral     51s  · max 127,972
   - { provider: "custom:litellm", model: "oc/minimax-m3" }       # Ollama Cloud (กลับมาเมื่อโควตารีเซ็ต)
   - { provider: "custom:litellm", model: "nim/minimax-m3" }      # NVIDIA NIM
@@ -240,8 +245,8 @@ quick_commands:
     description: สลับไป minimax (Ollama Cloud)
   big:
     type: alias
-    target: model or/ox-alpha            # context 1M แต่ ~19s
-    description: สลับไปโมเดล context ใหญ่ (or/ox-alpha)
+    target: model zen/hy3                # verified_max_prompt 127,968 · reasoning
+    description: สลับไปโมเดล context ใหญ่ (zen/hy3)
   nim:
     type: alias
     target: model nim/minimax-m3         # minimax ตัวเดียวกัน คนละเจ้า

--- a/templates/bot-service-hermes/config/config.yaml.tmpl
+++ b/templates/bot-service-hermes/config/config.yaml.tmpl
@@ -40,14 +40,19 @@ custom_providers:
     # (gateway มี 72 โมเดล ส่วนใหญ่ Hermes ใช้ไม่ได้ — ดู docs/MODEL-PROBE.md)
     discover_models: false
     models:
-      # เฉพาะตัวที่ผ่านครบ 3 ข้อ: tool_calls จริง / รับ prompt 14K / ตอบไทยรู้เรื่อง
-      - oc/minimax-m3          # Ollama Cloud  2.3s ← main
-      - nim/minimax-m3         # NVIDIA NIM    5.6s (คนละ provider กับตัวบน)
-      - mi/large               # Mistral       1B token/เดือน
-      - or/ox-alpha            # OpenRouter    context 1M
-      - cb/gpt-oss-120b        # Cerebras      เร็วสุด 0.4s แต่ชน TPM ง่าย
-      - oc/gpt-oss-120b        # Ollama Cloud  เร็วแต่หลุดไปตอบจีน/อังกฤษ (ดู docs)
-      - oc/nemotron-3-ultra    # Ollama Cloud  ใหญ่สุดที่ฟรี แต่ช้า
+      # เฉพาะตัวที่ผ่านครบ 4 ข้อ: tool_calls จริง / prompt 14K / tool loop turn 2 /
+      # อยู่กับภาษาไทยตอนวิ่งใน agent loop จริง (ข้อหลังยิง API ตรงวัดไม่เห็น)
+      # เวลาคือ "ต่อ turn จริงใน Hermes" ไม่ใช่ latency ของ call เดี่ยว
+      - mi/ministral-14b       # Mistral    18s   ← main · 1B token/เดือน
+      - mi/devstral-medium     # Mistral    51s   ใกล้เพดาน reply token ของ LINE (60s)
+      - or/ox-alpha            # OpenRouter ~19s  context 1M
+      - cb/gpt-oss-120b        # Cerebras   เร็วสุด แต่ verified_max_prompt แค่ 13,655
+                               #            และค้างเงียบที่ ~32K — เลือกเองได้ แต่ไม่อยู่ใน fallback
+      - oc/minimax-m3          # Ollama Cloud 2.3s — ⚠️ โควตา "รายสัปดาห์" หมดทั้งตระกูล
+      - nim/minimax-m3         # NVIDIA NIM  40 RPM
+      - mi/large               # Mistral    90-180s ช้ามาก เก็บไว้เป็นตาข่ายท้าย ๆ
+      # ตัดออก: oc/gpt-oss-120b (หลุดไปตอบจีน) · cf/llama-4-scout (ตอบอังกฤษ 1/3)
+      #         mi/magistral-medium (146-227s/turn ช้าเกินใช้กับแชท)
 
 # --- model ที่ใช้ ------------------------------------------------------------
 model:
@@ -58,30 +63,48 @@ model:
 # ต้องข้าม "ผู้ให้บริการ" ไม่ใช่แค่ข้ามชื่อโมเดล — โควตาผูกกับ provider
 # แต่ละ entry ต้องมีทั้ง provider และ model ไม่งั้นถูกข้ามเงียบ ๆ
 # LiteLLM มี fallbacks ของตัวเองอีกชั้นด้วย (litellm/config.yaml) — ชั้นนี้คือกันเหนียว
+# เรียงให้ "ข้าม provider" ทุกชั้น และเอาตัวที่เร็วกว่าไว้ก่อน
+# ⚠️ อย่าเรียง mi/* ต่อกันเป็นชั้นแรก — โควตาผูกกับ provider ตายพร้อมกัน
 fallback_providers:
-  - { provider: "custom:litellm", model: "nim/minimax-m3" }    # NVIDIA NIM — รุ่นเดียวกัน คนละเจ้า
-  - { provider: "custom:litellm", model: "mi/large" }          # Mistral
-  - { provider: "custom:litellm", model: "or/ox-alpha" }       # OpenRouter
-  - { provider: "custom:litellm", model: "cb/gpt-oss-120b" }   # Cerebras
+  - { provider: "custom:litellm", model: "or/ox-alpha" }         # OpenRouter  ~19s · max 31,833
+  - { provider: "custom:litellm", model: "mi/devstral-medium" }  # Mistral     51s  · max 127,972
+  - { provider: "custom:litellm", model: "oc/minimax-m3" }       # Ollama Cloud (กลับมาเมื่อโควตารีเซ็ต)
+  - { provider: "custom:litellm", model: "nim/minimax-m3" }      # NVIDIA NIM
+  # ⚠️ ถอด cb/gpt-oss-120b ออกจาก chain — verified_max_prompt แค่ 13,655 ซึ่งต่ำกว่า
+  #    context ที่ hermes ใช้จริง (สูงสุด 43,330) และมันพังแบบ "ค้างเงียบ" ไม่คืน error
+  #    fallback ที่ล้มแบบเงียบแย่กว่าไม่มี fallback เพราะกินเวลา timeout ไปเปล่า ๆ
 
 # --- auxiliary --------------------------------------------------------------
-# งานเบื้องหลังต้องอยู่คนละ provider กับ main ไม่งั้นดูดโควตาถังเดียวกัน
-# main = oc/* (Ollama Cloud) → aux ไปลง Cerebras ซึ่งเร็วและไม่ได้ใช้เป็นตัวหลัก
+# 🔴 ข้อจำกัดที่ผูกจริงของ aux คือ "ต้องไม่ค้างตอน prompt ใหญ่" ไม่ใช่ "คนละถังกับ main"
+#
+# เดิมตั้งกติกาว่า aux ต้องอยู่คนละ provider กับ main (กันดูดโควตาถังเดียวกัน)
+# ซึ่งถูกตอน main เป็น OKMD ที่มีแค่ ~40K/วัน — แต่ตอนนี้ main อยู่ Mistral
+# 1B token/เดือน เรื่องแย่งโควตาไม่ใช่ประเด็นแล้ว
+#
+# ที่เป็นประเด็นแทนคือ compression ทำงาน "ตอน context ใหญ่" ซึ่งเป็นจังหวะที่
+# โมเดลเพดานเตี้ยจะพัง — และบางเจ้าพังแบบ "เงียบ" ไม่คืน error ด้วย
+#   cb/gpt-oss-120b: verified_max_prompt = 13,655 · timeout ที่ ~32,000 (ไม่ตอบอะไรเลย)
+#   hermes ของเรา  : call แรก ~13,357 · call ถัดไปสูงสุด 43,330 (วัดจาก log จริง)
+# → Cerebras จะค้างพอดีตอนที่ compression ถูกเรียก จึงย้ายออก
+#
+# mi/ministral-3b: 373ms · verified_max_prompt 127,972 · เล็กและถูกที่สุดในตระกูล
+# (ตัวเลข verified_max_prompt มาจาก /model/info ของ llm-gateway — ค่าที่ยิงผ่านจริง
+#  ไม่ใช่ค่าที่ provider โฆษณา)
 auxiliary:
   compression:
     provider: custom:litellm
-    model: cb/gpt-oss-120b
+    model: mi/ministral-3b
   title_generation:
     provider: custom:litellm
-    model: cb/gpt-oss-120b
+    model: mi/ministral-3b
   skills_hub:
     provider: custom:litellm
-    model: cb/gpt-oss-120b
+    model: mi/ministral-3b
   # gateway ยังไม่มีโมเดล vision (or/nemotron-vl-12b ถูกถอด endpoint 2026-08-23)
   # รูปที่ส่งเข้า LINE จะไม่ถูกอ่าน จนกว่าจะเพิ่มโมเดล vision ใน LiteLLM
 
 # --- context ----------------------------------------------------------------
-# Hermes ยิงพื้น ~13.5K tokens ทุก call (system prompt + skills)
+# Hermes ยิงพื้น ~13K tokens ทุก call (system prompt + tool schemas)
 # บีบให้แน่นกว่า default (0.5) เพราะแชท LINE เป็น multi-turn ยาว
 compression:
   enabled: true

--- a/templates/bot-service-hermes/config/config.yaml.tmpl
+++ b/templates/bot-service-hermes/config/config.yaml.tmpl
@@ -1,0 +1,209 @@
+# ============================================================================
+# Hermes Agent × LINE OA × LiteLLM — template
+#
+# scripts/init.sh แทน ${VAR} ด้วยค่าจาก .env แล้วเขียนออกเป็น data/config.yaml
+# แก้ที่ไฟล์นี้เท่านั้น อย่าแก้ data/config.yaml ตรง ๆ (gitignore + โดนทับ)
+#
+# ทุก key verify กับ source ใน image v2026.8.3 แล้ว ไม่ได้ลอกจาก doc เว็บ
+#   - hermes_cli/config.py:_normalize_custom_provider_entry → providers.<name>.*
+#   - gateway/config.py:PlatformConfig.from_dict            → platforms.<name>.*
+#   - plugins/platforms/line/adapter.py                     → platforms.line.extra.*
+#   - hermes_cli/config_defaults.py:DEFAULT_CONFIG          → ที่เหลือ
+# ============================================================================
+
+# ต้องมี ไม่งั้น Hermes อ่านเป็น version 0 แล้วขึ้น
+# "This config predates version 12 ... can no longer be auto-migrated"
+# v2026.8.3 → 33  ตอนอัป HERMES_VERSION ให้รัน `docker compose run --rm hermes config migrate`
+_config_version: 33
+
+# --- provider: LiteLLM gateway ----------------------------------------------
+# base URL รับได้ 3 ชื่อ: api / url / base_url (โค้ดไล่หาตามลำดับนี้)
+# key_env = "ชื่อ" env var ไม่ใช่ตัว key — ค่าจริงส่งเข้ามาทาง docker-compose
+#
+# 🔴 ใช้รูปแบบ list (custom_providers) ไม่ใช่ dict (providers:) — ตั้งใจ ไม่ใช่ของเก่า
+#
+# ถ้าประกาศเป็น `providers: {litellm: ...}` Hermes จะนับ provider ตัวนี้ "สองครั้ง"
+#   - จาก key ของ dict            → slug `litellm`
+#   - จากตัวแปลงเป็น custom       → slug `custom:<name>`
+# แล้ว hermes_cli/model_switch.py:_configured_provider_matches() เห็น 2 provider
+# ประกาศโมเดลชื่อเดียวกัน จึงปฏิเสธทุกครั้งที่พิมพ์ชื่อโมเดลเปล่า ๆ:
+#   "'nim/minimax-m3' is declared by multiple configured providers ..."
+# ทำให้ /model ในแชท LINE ต้องพิมพ์ litellm/<ชื่อ> นำหน้าเสมอ ซึ่งไม่มีใครจำ
+#
+# พอย้ายมาเป็น list ตัวซ้ำหายไป (providers dict ว่าง) — ยืนยันด้วยการเรียก
+# switch_model() ตรง ๆ แล้ว ใช้ได้ทั้ง `nim/minimax-m3` และ `litellm/nim/minimax-m3`
+custom_providers:
+  - name: litellm
+    api: ${LITELLM_BASE_URL}
+    key_env: LITELLM_KEY
+    # false = เชื่อรายชื่อข้างล่าง ไม่ต้องไปถาม /models ตอน start
+    # (gateway มี 72 โมเดล ส่วนใหญ่ Hermes ใช้ไม่ได้ — ดู docs/MODEL-PROBE.md)
+    discover_models: false
+    models:
+      # เฉพาะตัวที่ผ่านครบ 3 ข้อ: tool_calls จริง / รับ prompt 14K / ตอบไทยรู้เรื่อง
+      - oc/minimax-m3          # Ollama Cloud  2.3s ← main
+      - nim/minimax-m3         # NVIDIA NIM    5.6s (คนละ provider กับตัวบน)
+      - mi/large               # Mistral       1B token/เดือน
+      - or/ox-alpha            # OpenRouter    context 1M
+      - cb/gpt-oss-120b        # Cerebras      เร็วสุด 0.4s แต่ชน TPM ง่าย
+      - oc/gpt-oss-120b        # Ollama Cloud  เร็วแต่หลุดไปตอบจีน/อังกฤษ (ดู docs)
+      - oc/nemotron-3-ultra    # Ollama Cloud  ใหญ่สุดที่ฟรี แต่ช้า
+
+# --- model ที่ใช้ ------------------------------------------------------------
+model:
+  provider: custom:litellm
+  default: ${HERMES_MODEL}
+
+# --- fallback ---------------------------------------------------------------
+# ต้องข้าม "ผู้ให้บริการ" ไม่ใช่แค่ข้ามชื่อโมเดล — โควตาผูกกับ provider
+# แต่ละ entry ต้องมีทั้ง provider และ model ไม่งั้นถูกข้ามเงียบ ๆ
+# LiteLLM มี fallbacks ของตัวเองอีกชั้นด้วย (litellm/config.yaml) — ชั้นนี้คือกันเหนียว
+fallback_providers:
+  - { provider: "custom:litellm", model: "nim/minimax-m3" }    # NVIDIA NIM — รุ่นเดียวกัน คนละเจ้า
+  - { provider: "custom:litellm", model: "mi/large" }          # Mistral
+  - { provider: "custom:litellm", model: "or/ox-alpha" }       # OpenRouter
+  - { provider: "custom:litellm", model: "cb/gpt-oss-120b" }   # Cerebras
+
+# --- auxiliary --------------------------------------------------------------
+# งานเบื้องหลังต้องอยู่คนละ provider กับ main ไม่งั้นดูดโควตาถังเดียวกัน
+# main = oc/* (Ollama Cloud) → aux ไปลง Cerebras ซึ่งเร็วและไม่ได้ใช้เป็นตัวหลัก
+auxiliary:
+  compression:
+    provider: custom:litellm
+    model: cb/gpt-oss-120b
+  title_generation:
+    provider: custom:litellm
+    model: cb/gpt-oss-120b
+  skills_hub:
+    provider: custom:litellm
+    model: cb/gpt-oss-120b
+  # gateway ยังไม่มีโมเดล vision (or/nemotron-vl-12b ถูกถอด endpoint 2026-08-23)
+  # รูปที่ส่งเข้า LINE จะไม่ถูกอ่าน จนกว่าจะเพิ่มโมเดล vision ใน LiteLLM
+
+# --- context ----------------------------------------------------------------
+# Hermes ยิงพื้น ~13.5K tokens ทุก call (system prompt + skills)
+# บีบให้แน่นกว่า default (0.5) เพราะแชท LINE เป็น multi-turn ยาว
+compression:
+  enabled: true
+  threshold: 0.40
+  target_ratio: 0.25
+  protect_last_n: 20
+
+# --- messaging platform: LINE -----------------------------------------------
+# adapter เป็น bundled plugin (plugins/platforms/line) — enable ตรงนี้พอ
+# ไม่ต้องลงอะไรเพิ่ม
+platforms:
+  line:
+    enabled: true
+    # ⚠️ ห้ามใส่ channel_access_token / channel_secret ตรงนี้
+    #    adapter อ่าน env ก่อน extra เสมอ และไฟล์นี้ไม่ได้ chmod 600
+    #    creds อยู่ใน .env → docker-compose → env ของ process
+    extra:
+      # ต้องตรงกับ port ที่ publish ใน docker-compose.yml
+      port: ${LINE_PORT}
+      host: "0.0.0.0"
+      # path นี้ต้องตรงกับ Webhook URL ที่ตั้งใน LINE Console
+      #   https://<โดเมนของ project>/webhook
+      # ค่า default ของ Hermes adapter คือ /line/webhook แต่ botforge ใช้ /webhook
+      # เหมือนกันทุก engine — ตั้งตามนั้นเพื่อให้คู่มือใช้ร่วมกันได้
+      # ถ้าแก้ตรงนี้ ต้องแก้ LINE_WEBHOOK_PATH ใน .env ให้ตรงด้วย
+      # (scripts/smoke-webhook.sh อ่านจากตรงนั้น)
+      webhook_path: /webhook
+      # 🔴 อนุญาต "ทุกคนในกลุ่มนี้" — ไม่ใช่แค่ id ที่อยู่ใน LINE_ALLOWED_USERS
+      #
+      # ทำไมต้องมีทั้งที่ LINE_ALLOWED_GROUPS ก็ตั้งไว้แล้ว: มันคนละด่านกัน
+      #   ด่าน 1  adapter (_allowed_for_source)  — เช็ค groupId อย่างเดียว ผ่าน
+      #   ด่าน 2  gateway (_is_user_authorized)  — เช็ค "รายคน" จาก LINE_ALLOWED_USERS
+      #           ผ่าน platform_registry (adapter.py:1741) → เพื่อนร่วมทีมโดนตีตกที่ด่านนี้
+      #           ขึ้น log ว่า "Unauthorized user: U… on line" ทั้งที่ webhook ตอบ 200
+      #
+      # group_allowed_chats ถูกเช็คใน authz_mixin.py:478 ก่อนถึง user allowlist
+      # และเป็นทางที่ platform-agnostic (ไม่ต้องรอ Hermes ใส่ LINE ในตาราง hardcode)
+      # ใส่ "*" = ทุกกลุ่มที่ผ่านด่าน 1 (ยังคุมด้วย LINE_ALLOWED_GROUPS อยู่)
+      group_allowed_chats: ${LINE_GROUP_ALLOWED_CHATS}
+    # ปิด ping "♻️ Gateway online" ทุกครั้งที่ restart — ผู้ใช้ปลายทางไม่ได้อยากรู้
+    gateway_restart_notification: false
+    # LINE มี loading indicator ของตัวเอง (chat/loading/start) เปิดไว้
+    typing_indicator: true
+
+# --- พฤติกรรมในกลุ่ม ---------------------------------------------------------
+# false = ทั้งกลุ่มใช้ session เดียวกัน บอทเห็นบทสนทนาต่อเนื่องของทุกคน
+#         → เหมาะกับ "ผู้ช่วยประจำกลุ่ม" ซึ่งคือโจทย์ของ POC นี้
+# true (default ของ Hermes) = แยก session รายคนในกลุ่ม บอทจำข้ามคนไม่ได้
+#         → เหมาะกับกลุ่มที่ต้องการความเป็นส่วนตัวรายคน
+group_sessions_per_user: false
+
+# ⚠️ ไม่มีเงื่อนไข @mention — ในกลุ่มที่ allowlist ผ่าน บอทตอบ "ทุกข้อความ"
+#    (ตรวจแล้ว: adapter.py ไม่มี logic mention เลย ต่างจาก Mattermost ที่มี
+#     MATTERMOST_REQUIRE_MENTION) กลุ่มที่คนคุยกันเยอะจะกินโควตาโมเดลเร็วมาก
+#    คุมด้วย LINE_ALLOWED_GROUPS ให้แคบไว้ก่อน
+
+# --- toolsets ที่เปิดให้ agent ใช้ -------------------------------------------
+# นี่คือ "allowlist" ไม่ใช่ blocklist — ตัวที่ไม่อยู่ในลิสต์ = ปิด
+# ตัวเลข: tool schemas คือก้อนที่ใหญ่ที่สุดของพื้นต่อ call ใหญ่กว่า system prompt
+# ทั้งก้อน ตัด 4 ตัวข้างล่างแล้วได้ 44,758 B → 31,772 B (27 tools → 14)
+#
+# ที่ตัดออกและเหตุผล:
+#   browser    (6,341 B / 10 tools) ต้องมี chrome + shm 1g  แชท LINE ไม่ได้ใช้
+#   delegation (3,859 B) แตก sub-agent — เพิ่ม turn เพิ่มโควตา ไม่คุ้มกับแชท
+#   tts        (1,834 B) ยังไม่ได้ตั้งเสียงออกทาง LINE
+#   vision       (926 B) LiteLLM gateway ไม่มีโมเดล vision (docs/MODEL-PROBE.md)
+#
+# ⚠️ `hermes tools disable --platform line` ใช้ไม่ได้ — validator ของ CLI รู้จัก
+#    เฉพาะ platform ที่ built-in (cli, telegram, discord, ...) ไม่รู้จัก plugin
+#    platform อย่าง line  แต่ "ตัวอ่าน config" รู้จัก ยืนยันด้วย
+#    `hermes prompt-size --platform line` แล้วตัวเลขลดจริง → เขียน key line ตรงนี้เอง
+#
+# ⚠️ `hermes tools disable` เขียนทับ data/config.yaml โดยตรง ถ้าใช้คำสั่งนั้น
+#    แล้วรัน ./scripts/init.sh --force ทีหลัง ค่าจะหายไป — แก้ที่ไฟล์นี้เท่านั้น
+platform_toolsets:
+  # ที่ LINE ใช้จริง
+  line: &enabled_toolsets
+    - clarify           # ถามกลับเมื่อโจทย์กำกวม
+    - code_execution
+    - cronjob           # งานตามเวลา ส่งเข้า LINE_HOME_CHANNEL
+    - file
+    - kanban
+    - memory            # จำข้ามรอบคุย
+    - session_search    # ค้นบทสนทนาเก่า
+    - skills
+    - terminal
+    - todo
+    - web               # ค้นเว็บ (provider brave-free / ddgs ไม่ต้องใช้ key)
+    - bfl
+    - computer_use
+    - image_gen
+  # ให้ CLI เหมือนกัน จะได้ทดสอบด้วย `hermes -z` แล้วเจอสภาพเดียวกับที่ LINE เจอ
+  cli: *enabled_toolsets
+
+# --- ทางลัดสลับโมเดล ---------------------------------------------------------
+# type: alias = เขียนคำสั่งใหม่แล้วส่งต่อให้ handler ของจริง (gateway/run.py:14862)
+# target ไม่ต้องมี / นำหน้า และ argument ที่ผู้ใช้พิมพ์ต่อท้ายจะถูกส่งตามไปด้วย
+# ไม่ใช่ type: exec — exec คือรัน shell ซึ่งไม่ใช่สิ่งที่ต้องการตรงนี้
+#
+# พิมพ์ /model <ชื่อ> ตรง ๆ ก็ยังได้ ทางลัดนี้ไว้ให้จำง่ายตอนคุยใน LINE
+quick_commands:
+  fast:
+    type: alias
+    target: model oc/minimax-m3          # 2.6s — ตัวเร็วสุดที่ตอบไทยนิ่ง
+    description: สลับไปโมเดลเร็ว (oc/minimax-m3)
+  big:
+    type: alias
+    target: model or/ox-alpha            # context 1M แต่ ~19s
+    description: สลับไปโมเดล context ใหญ่ (or/ox-alpha)
+  nim:
+    type: alias
+    target: model nim/minimax-m3         # minimax ตัวเดียวกัน คนละเจ้า
+    description: สลับไป minimax ฝั่ง NVIDIA NIM
+  mistral:
+    type: alias
+    target: model mi/large
+    description: สลับไป Mistral Large
+
+agent:
+  max_turns: ${HERMES_MAX_TURNS}
+
+logging:
+  level: INFO
+
+timezone: ${TZ}

--- a/templates/bot-service-hermes/config/config.yaml.tmpl
+++ b/templates/bot-service-hermes/config/config.yaml.tmpl
@@ -103,12 +103,11 @@ platforms:
       port: ${LINE_PORT}
       host: "0.0.0.0"
       # path นี้ต้องตรงกับ Webhook URL ที่ตั้งใน LINE Console
-      #   https://<โดเมนของ project>/webhook
-      # ค่า default ของ Hermes adapter คือ /line/webhook แต่ botforge ใช้ /webhook
-      # เหมือนกันทุก engine — ตั้งตามนั้นเพื่อให้คู่มือใช้ร่วมกันได้
-      # ถ้าแก้ตรงนี้ ต้องแก้ LINE_WEBHOOK_PATH ใน .env ให้ตรงด้วย
-      # (scripts/smoke-webhook.sh อ่านจากตรงนั้น)
-      webhook_path: /webhook
+      #   https://<โดเมนของ project><path>
+      # อ่านจาก LINE_WEBHOOK_PATH ใน .env ที่เดียว — scripts/smoke-webhook.sh
+      # ก็อ่านจากตรงนั้น จะได้ไม่หลุดคนละค่ากันสองที่
+      # ค่า default ของ Hermes adapter เองคือ /line/webhook
+      webhook_path: ${LINE_WEBHOOK_PATH}
       # 🔴 อนุญาต "ทุกคนในกลุ่มนี้" — ไม่ใช่แค่ id ที่อยู่ใน LINE_ALLOWED_USERS
       #
       # ทำไมต้องมีทั้งที่ LINE_ALLOWED_GROUPS ก็ตั้งไว้แล้ว: มันคนละด่านกัน
@@ -120,7 +119,9 @@ platforms:
       # group_allowed_chats ถูกเช็คใน authz_mixin.py:478 ก่อนถึง user allowlist
       # และเป็นทางที่ platform-agnostic (ไม่ต้องรอ Hermes ใส่ LINE ในตาราง hardcode)
       # ใส่ "*" = ทุกกลุ่มที่ผ่านด่าน 1 (ยังคุมด้วย LINE_ALLOWED_GROUPS อยู่)
-      group_allowed_chats: ${LINE_GROUP_ALLOWED_CHATS}
+      # ต้องมี quote — ค่า * ล้วน ๆ YAML อ่านเป็น alias แล้ว parse พัง
+      # (hermes config check ไม่จับให้ ต้อง parse เองถึงจะเห็น)
+      group_allowed_chats: "${LINE_GROUP_ALLOWED_CHATS}"
     # ปิด ping "♻️ Gateway online" ทุกครั้งที่ restart — ผู้ใช้ปลายทางไม่ได้อยากรู้
     gateway_restart_notification: false
     # LINE มี loading indicator ของตัวเอง (chat/loading/start) เปิดไว้

--- a/templates/bot-service-hermes/config/config.yaml.tmpl
+++ b/templates/bot-service-hermes/config/config.yaml.tmpl
@@ -182,11 +182,24 @@ platform_toolsets:
 # ไม่ใช่ type: exec — exec คือรัน shell ซึ่งไม่ใช่สิ่งที่ต้องการตรงนี้
 #
 # พิมพ์ /model <ชื่อ> ตรง ๆ ก็ยังได้ ทางลัดนี้ไว้ให้จำง่ายตอนคุยใน LINE
+# ⚠️ ชื่อ quick command ต้องไม่ชนกับคำสั่ง built-in ของ Hermes
+#    ถ้าชน alias จะ "ไม่ทำงานเลย" แบบเงียบ ๆ เพราะ gateway/run.py:14855 เช็ค
+#    `_cmd_def is None` ก่อน — เจอ built-in แล้วจะไม่มองหา alias เลย
+#    เคยตั้ง `fast` แล้วชนกับ /fast (สลับ Priority Processing) จึงเปลี่ยนเป็น turbo
+#
+#    เช็คก่อนตั้งชื่อใหม่:
+#      docker exec <container> /opt/hermes/.venv/bin/python -c \
+#        "import sys;sys.path.insert(0,'/opt/hermes');\
+#         from hermes_cli.commands import is_gateway_known_command as k;print(k('ชื่อ'))"
 quick_commands:
-  fast:
+  turbo:
     type: alias
     target: model oc/minimax-m3          # 2.6s — ตัวเร็วสุดที่ตอบไทยนิ่ง
     description: สลับไปโมเดลเร็ว (oc/minimax-m3)
+  minimax:
+    type: alias
+    target: model oc/minimax-m3          # ชื่อที่อ่านแล้วรู้เลยว่าโมเดลอะไร
+    description: สลับไป minimax (Ollama Cloud)
   big:
     type: alias
     target: model or/ox-alpha            # context 1M แต่ ~19s

--- a/templates/bot-service-hermes/config/skills-keep.txt
+++ b/templates/bot-service-hermes/config/skills-keep.txt
@@ -1,0 +1,21 @@
+# skills ที่ให้ seed เข้า data/skills/ — หนึ่งบรรทัดต่อหนึ่งตัว รูปแบบ <หมวด>/<ชื่อ>
+# บรรทัดว่างและบรรทัดขึ้นต้นด้วย # ถูกข้าม
+#
+# ที่มา: image มี bundled skills 71 ตัว แต่ index ของทั้ง 71 ตัวถูกยัดเข้า
+# system prompt "ทุก call" (6.7 KB) ทั้งที่โจทย์นี้ไม่ได้ใช้ apple/imessage,
+# comfyui, manim-video, polymarket, touchdesigner ฯลฯ เลยสักตัว
+#
+# แก้ไฟล์นี้แล้วรัน:  ./scripts/trim-skills.sh
+# ดูรายชื่อทั้งหมดที่เลือกได้:  ./scripts/trim-skills.sh --list-available
+
+# ── ถามบอทเรื่องตัวมันเองได้ — ระหว่าง POC ใช้บ่อยที่สุด ────────────────
+autonomous-ai-agents/hermes-agent
+
+# ── ตอบคำถามแบบมีที่มาอ้างอิง ไม่มั่ว ─────────────────────────────────
+research/grounded-citations
+
+# ── คนส่งไฟล์เข้า LINE บ่อย — adapter ดึงไฟล์เข้า media cache ให้แล้ว ──
+# (ทั้งสองตัวเป็นการสกัด "ข้อความ" ไม่ใช่ vision จึงใช้ได้แม้ gateway
+#  ยังไม่มีโมเดล vision — ดู docs/MODEL-PROBE.md)
+productivity/ocr-and-documents
+productivity/pdf

--- a/templates/bot-service-hermes/docker-compose.yml
+++ b/templates/bot-service-hermes/docker-compose.yml
@@ -1,0 +1,106 @@
+# --------------------------------------------------------------------------
+# Hermes Agent → LINE OA (1:1 + group + room)  ×  LiteLLM gateway
+#
+# 🔴 เทมเพลตนี้ไม่เหมือน engine ตัวอื่นของ botforge — ไม่มี line-bot ของ botforge
+#
+# engine อื่น:  LINE ──► botforge line-bot (bun + @line/bot-sdk) ──► engine server
+# hermes:       LINE ──► hermes (มี LINE adapter ในตัว 1,758 บรรทัด)
+#
+# Hermes เป็นเจ้าของ LINE channel เอง — ตรวจลายเซ็น HMAC, reply token, Push API,
+# group/room, media cache, ปุ่ม postback ตอนตอบช้า ทำมาให้หมดแล้ว
+# จึงไม่มี src/ ไม่มี Dockerfile ไม่มี package.json ในเทมเพลตนี้ มีแต่ config
+#
+# ⚠️ service ยังชื่อ `line-bot` และ container ยังเป็น {{CONTAINER_PREFIX}}-line-bot
+#    โดยตั้งใจ — `botforge-deploy tunnel setup` ตั้ง ingress ตายตัวไปที่
+#    http://{name}-line-bot:3000 และ `botforge-deploy status/rebuild` map ชื่อนี้
+#    ตั้งชื่ออื่นแล้ว tunnel จะ 502
+#
+# ครั้งแรก:  ./scripts/init.sh  แล้ว  docker compose up -d
+# --------------------------------------------------------------------------
+
+x-logging: &logging
+  logging:
+    driver: json-file
+    options: { max-size: "10m", max-file: "3" }
+
+services:
+  line-bot:
+    image: nousresearch/hermes-agent:${HERMES_VERSION:-v2026.8.3}
+    container_name: {{CONTAINER_PREFIX}}-line-bot
+    command: gateway run
+    environment:
+      # --- model: มาจาก LiteLLM gateway ---------------------------------------
+      # key_env ใน data/config.yaml ชี้มาที่ชื่อตัวแปรนี้
+      # ด่านตรวจอยู่ที่ ./scripts/init.sh — ไม่ใช้ :? ตรงนี้เพราะจะทำให้
+      # `docker compose ps/config` ของ project ที่เพิ่ง scaffold พังทั้งหมด
+      LITELLM_KEY: ${LITELLM_KEY:-}
+
+      # --- LINE Messaging API ------------------------------------------------
+      # adapter อ่าน env ก่อน extra ใน config.yaml เสมอ — creds อยู่ที่นี่ที่เดียว
+      LINE_CHANNEL_ACCESS_TOKEN: ${LINE_CHANNEL_ACCESS_TOKEN:-}
+      LINE_CHANNEL_SECRET: ${LINE_CHANNEL_SECRET:-}
+      # 3000 = ที่ tunnel ของ botforge ชี้มา ห้ามเปลี่ยนถ้าไม่แก้ ingress ด้วย
+      LINE_PORT: ${LINE_PORT:-3000}
+      LINE_HOST: 0.0.0.0
+      # ต้องเป็น https ปลายทางจริง ใช้ตอนส่งรูป/เสียง/ไฟล์กลับเข้า LINE
+      LINE_PUBLIC_URL: ${LINE_PUBLIC_URL:-https://{{DOMAIN}}}
+      # allowlist 3 ชั้น: U... = คน, C... = group, R... = room
+      LINE_ALLOWED_USERS: ${LINE_ALLOWED_USERS:-}
+      LINE_ALLOWED_GROUPS: ${LINE_ALLOWED_GROUPS:-}
+      LINE_ALLOWED_ROOMS: ${LINE_ALLOWED_ROOMS:-}
+      # ⚠️ true = ใครก็คุยได้ ปิด allowlist ทั้งหมด — ใช้ตอนเก็บ id รอบแรกเท่านั้น
+      LINE_ALLOW_ALL_USERS: ${LINE_ALLOW_ALL_USERS:-false}
+      # ปลายทางของ cron / แจ้งเตือนที่บอทเริ่มเอง (ว่างได้)
+      LINE_HOME_CHANNEL: ${LINE_HOME_CHANNEL:-}
+      # reply token ของ LINE อายุ ~60s — เกินเกณฑ์นี้ยิงปุ่ม postback ให้กดรับคำตอบ
+      # ด้วย token ใหม่ (ฟรี) แทน Push ซึ่งกินโควตาข้อความของ OA
+      LINE_SLOW_RESPONSE_THRESHOLD: ${LINE_SLOW_RESPONSE_THRESHOLD:-45}
+
+      # --- runtime ------------------------------------------------------------
+      # image รันด้วย user hermes UID 10000 — ต้อง map ให้ตรง owner ของ ./data
+      PUID: ${PUID:-1001}
+      PGID: ${PGID:-1001}
+      HERMES_DASHBOARD: ${HERMES_DASHBOARD:-0}
+      HERMES_DASHBOARD_BASIC_AUTH_USERNAME: ${DASHBOARD_USER:-}
+      HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: ${DASHBOARD_PASS:-}
+      TZ: ${TZ:-Asia/Bangkok}
+    volumes:
+      # /opt/data = ทุกอย่างที่ persist: config.yaml sessions memories skills logs
+      - ./data:/opt/data
+      # workspace ของ project — ให้ agent เห็นไฟล์งานเหมือน engine ตัวอื่น
+      - ${PROJECT_DIR:-../workspace}:/workspace
+    # browser tool ต้องใช้ shm — ไม่ใส่แล้ว chrome crash (ถ้าปิด toolset browser ตัดได้)
+    shm_size: ${SHM_SIZE:-1g}
+    networks:
+      - default
+      # LiteLLM อยู่บนเน็ตเวิร์กนี้ — สร้างครั้งเดียวต่อเครื่อง:
+      #   docker network create llm-clients
+      #   docker network connect llm-clients llm-litellm
+      - llm-clients
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: ${MEM_LIMIT:-4G}
+          cpus: "${CPU_LIMIT:-2.0}"
+    <<: *logging
+
+  # ทางเข้า https สำหรับ LINE webhook — LINE ไม่ยิง http และไม่ยิง IP เปล่า
+  #   botforge-deploy tunnel setup {{PROJECT_NAME}}
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: {{CONTAINER_PREFIX}}-tunnel
+    # ค่าว่างจะพังตอน start ของ cloudflared เอง — ใช้ :- ไม่ใช่ :? เพราะ compose
+    # interpolate ทุก service เสมอ
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:-}
+    depends_on:
+      - line-bot
+    networks:
+      - default
+    restart: unless-stopped
+    <<: *logging
+
+networks:
+  default:
+  llm-clients:
+    external: true

--- a/templates/bot-service-hermes/docker-compose.yml
+++ b/templates/bot-service-hermes/docker-compose.yml
@@ -60,7 +60,14 @@ services:
       # image รันด้วย user hermes UID 10000 — ต้อง map ให้ตรง owner ของ ./data
       PUID: ${PUID:-1001}
       PGID: ${PGID:-1001}
+      # web dashboard 19 หน้า: Chat, Sessions (เห็นบทสนทนา LINE), Logs, Models,
+      # Config, Env, Skills, Cron, Channels, Pairing, Webhooks ฯลฯ
+      # ⚠️ แก้ env/config ได้จากหน้าเว็บ = คนที่เข้าได้เห็น LINE token / LiteLLM key
       HERMES_DASHBOARD: ${HERMES_DASHBOARD:-0}
+      # botforge tunnel เปิด route ที่สองไปที่ http://{name}-server:{port ของ engine}
+      # ตั้ง port ให้ตรงกับที่ ingress ชี้ (opencode ใช้ 4096) จะได้ไม่ต้องแก้ Cloudflare
+      HERMES_DASHBOARD_PORT: ${HERMES_DASHBOARD_PORT:-9119}
+      HERMES_DASHBOARD_HOST: 0.0.0.0
       HERMES_DASHBOARD_BASIC_AUTH_USERNAME: ${DASHBOARD_USER:-}
       HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: ${DASHBOARD_PASS:-}
       TZ: ${TZ:-Asia/Bangkok}
@@ -72,11 +79,17 @@ services:
     # browser tool ต้องใช้ shm — ไม่ใส่แล้ว chrome crash (ถ้าปิด toolset browser ตัดได้)
     shm_size: ${SHM_SIZE:-1g}
     networks:
-      - default
+      default:
+        aliases:
+          # route ที่สองของ tunnel ชี้ไปที่ {name}-server ตายตัว แต่ hermes ไม่มี
+          # container แยกชื่อนั้น (ทั้ง service คือตัว hermes เอง) — alias นี้ทำให้
+          # BOTFORGE_EXPOSE_HERMES_UI=1 + tunnel setup ใช้ได้จริง ไม่ 502
+          - {{CONTAINER_PREFIX}}-server
       # LiteLLM อยู่บนเน็ตเวิร์กนี้ — สร้างครั้งเดียวต่อเครื่อง:
       #   docker network create llm-clients
       #   docker network connect llm-clients llm-litellm
-      - llm-clients
+      # (mapping ไม่ใช่ list เพราะ default ข้างบนมี aliases — ปนกันไม่ได้)
+      llm-clients:
     restart: unless-stopped
     deploy:
       resources:

--- a/templates/bot-service-hermes/scripts/_lang.py
+++ b/templates/bot-service-hermes/scripts/_lang.py
@@ -1,0 +1,19 @@
+"""ดูว่าคำตอบใน $OUT เป็นภาษาอะไร — ใช้โดย probe-thai.sh"""
+import os
+import re
+
+text = os.environ.get("OUT", "")
+thai = len(re.findall(r"[฀-๿]", text))
+cjk = len(re.findall(r"[一-鿿]", text))
+latin = len(re.findall(r"[A-Za-z]", text))
+
+if not text.strip():
+    print("err")
+elif thai > 40:
+    print("th")
+elif cjk > 10:
+    print("zh")
+elif latin > 40:
+    print("en")
+else:
+    print("err")

--- a/templates/bot-service-hermes/scripts/init.sh
+++ b/templates/bot-service-hermes/scripts/init.sh
@@ -46,6 +46,7 @@ fi
 : "${HERMES_MODEL:=oc/gpt-oss-120b}"
 : "${HERMES_MAX_TURNS:=60}"
 : "${LINE_PORT:=8646}"
+: "${LINE_WEBHOOK_PATH:=/line/webhook}"
 : "${TZ:=Asia/Bangkok}"
 : "${PUID:=$(id -u)}"
 : "${PGID:=$(id -g)}"
@@ -114,15 +115,15 @@ else
   # แทนเฉพาะตัวแปรที่ตั้งใจ — ไม่ใช้ envsubst เปล่า ๆ กัน ${...} อื่นโดนกินไปด้วย
   # ถ้าไม่ตั้ง = ยกกลุ่มที่ผ่าน LINE_ALLOWED_GROUPS ให้ทั้งกลุ่ม (ตรงกับที่คนคาดหวัง
   # เวลาเชิญบอทเข้ากลุ่มทีม) ตั้งเป็นรายการ group id ถ้าอยากแคบกว่านั้น
-  : "${LINE_GROUP_ALLOWED_CHATS:=${LINE_ALLOWED_GROUPS:-\"*\"}}"
-  [ -n "$LINE_GROUP_ALLOWED_CHATS" ] || LINE_GROUP_ALLOWED_CHATS='"*"'
+  : "${LINE_GROUP_ALLOWED_CHATS:=${LINE_ALLOWED_GROUPS:-*}}"
+  [ -n "$LINE_GROUP_ALLOWED_CHATS" ] || LINE_GROUP_ALLOWED_CHATS="*"
   LITELLM_BASE_URL="$LITELLM_BASE_URL" HERMES_MODEL="$HERMES_MODEL" \
-  HERMES_MAX_TURNS="$HERMES_MAX_TURNS" LINE_PORT="$LINE_PORT" TZ="$TZ" \
+  HERMES_MAX_TURNS="$HERMES_MAX_TURNS" LINE_PORT="$LINE_PORT" LINE_WEBHOOK_PATH="$LINE_WEBHOOK_PATH" TZ="$TZ" \
   LINE_GROUP_ALLOWED_CHATS="$LINE_GROUP_ALLOWED_CHATS" \
   python3 -c '
 import os, re, sys
 allowed = ("LITELLM_BASE_URL", "HERMES_MODEL", "HERMES_MAX_TURNS", "LINE_PORT", "TZ",
-           "LINE_GROUP_ALLOWED_CHATS")
+           "LINE_GROUP_ALLOWED_CHATS", "LINE_WEBHOOK_PATH")
 src = open(sys.argv[1], encoding="utf-8").read()
 out = re.sub(r"\$\{(\w+)\}", lambda m: os.environ[m.group(1)] if m.group(1) in allowed else m.group(0), src)
 open(sys.argv[2], "w", encoding="utf-8").write(out)

--- a/templates/bot-service-hermes/scripts/init.sh
+++ b/templates/bot-service-hermes/scripts/init.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# ============================================================================
+# init.sh — เตรียม data/ ให้พร้อมก่อน docker compose up ครั้งแรก
+#
+#   ./scripts/init.sh           # สร้างของที่ยังไม่มี ไม่แตะของเดิม
+#   ./scripts/init.sh --force   # เขียน data/config.yaml ทับจาก template
+#
+# ทำ 5 อย่าง:
+#   1. ตรวจ .env (LITELLM_KEY บังคับ / LINE creds เตือนถ้าขาด)
+#   2. สร้าง data/ + โครงย่อย แล้ว chown ให้ตรง PUID/PGID
+#   3. gen data/config.yaml จาก config/config.yaml.tmpl
+#   4. ตรวจว่า network llm-clients + LiteLLM ต่อติดจริง
+#   5. ให้ hermes ตรวจ config ตัวเอง
+#
+# รันซ้ำได้ปลอดภัย — ของเดิมไม่ถูกแตะ ยกเว้นสั่ง --force
+# ============================================================================
+set -euo pipefail
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'
+BLUE=$'\033[0;34m'; DIM=$'\033[2m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FORCE=false
+[ "${1:-}" = "--force" ] && FORCE=true
+
+# ---------------------------------------------------------------- 1. env ---
+echo
+echo "${BOLD}${BLUE}▸ 1. ตรวจ .env${RESET}"
+
+if [ ! -f .env ]; then
+  echo "${RED}  ✗ ไม่มี .env${RESET}"
+  echo "    cp .env.example .env  แล้วเติม LITELLM_KEY + LINE creds"
+  exit 1
+fi
+set -a; . ./.env; set +a
+
+if [ -z "${LITELLM_KEY:-}" ]; then
+  echo "${RED}  ✗ LITELLM_KEY ว่าง${RESET}"
+  echo "    ออก virtual key จาก LiteLLM (อย่าใช้ master key)"
+  exit 1
+fi
+
+: "${LITELLM_BASE_URL:=http://llm-litellm:4000/v1}"
+: "${HERMES_MODEL:=oc/gpt-oss-120b}"
+: "${HERMES_MAX_TURNS:=60}"
+: "${LINE_PORT:=8646}"
+: "${TZ:=Asia/Bangkok}"
+: "${PUID:=$(id -u)}"
+: "${PGID:=$(id -g)}"
+
+perm=$(stat -c '%a' .env)
+if [ "$perm" != "600" ]; then
+  chmod 600 .env
+  echo "${YELLOW}  ! .env เปิดกว้างไป ($perm) → แก้เป็น 600 ให้แล้ว${RESET}"
+fi
+echo "${GREEN}  ok${RESET} ${DIM}(key ${LITELLM_KEY:0:8}… / model $HERMES_MODEL / uid $PUID:$PGID)${RESET}"
+
+# LINE creds ยังไม่มีก็ทำงานต่อได้ — gateway จะขึ้นแต่ adapter LINE ไม่ start
+LINE_READY=true
+if [ -z "${LINE_CHANNEL_ACCESS_TOKEN:-}" ] || [ -z "${LINE_CHANNEL_SECRET:-}" ]; then
+  LINE_READY=false
+  echo "${YELLOW}  ! LINE_CHANNEL_ACCESS_TOKEN / LINE_CHANNEL_SECRET ยังว่าง${RESET}"
+  echo "${DIM}    gateway จะขึ้นได้ แต่ LINE adapter จะไม่ start จนกว่าจะเติม${RESET}"
+fi
+if [ "${LINE_ALLOW_ALL_USERS:-false}" = "true" ]; then
+  echo "${YELLOW}  ! LINE_ALLOW_ALL_USERS=true — ใครก็คุยกับบอทได้ ใช้เก็บ id เท่านั้น${RESET}"
+elif [ "$LINE_READY" = true ] \
+  && [ -z "${LINE_ALLOWED_USERS:-}" ] && [ -z "${LINE_ALLOWED_GROUPS:-}" ] && [ -z "${LINE_ALLOWED_ROOMS:-}" ]; then
+  echo "${YELLOW}  ! allowlist ว่างทั้ง 3 ชั้น — บอทจะปฏิเสธทุกข้อความ${RESET}"
+  echo "${DIM}    เก็บ id รอบแรกด้วย LINE_ALLOW_ALL_USERS=true แล้วดู logs${RESET}"
+fi
+
+# ---------------------------------------------------------------- 2. dirs --
+echo
+echo "${BOLD}${BLUE}▸ 2. เตรียม data/${RESET}"
+
+for d in data data/sessions data/memories data/skills data/logs data/home data/profiles; do
+  if [ -d "$d" ]; then
+    echo "${DIM}  มีอยู่แล้ว  $d${RESET}"
+  else
+    mkdir -p "$d"
+    echo "${GREEN}  สร้าง      $d${RESET}"
+  fi
+done
+
+cur="$(stat -c '%u:%g' data)"
+if [ "$cur" != "$PUID:$PGID" ]; then
+  if chown -R "$PUID:$PGID" data 2>/dev/null; then
+    echo "${GREEN}  chown${RESET} ${DIM}data/ → $PUID:$PGID${RESET}"
+  else
+    echo "${YELLOW}  ! chown data/ ไม่สำเร็จ (ต้องใช้ sudo)${RESET}"
+    echo "${DIM}    sudo chown -R $PUID:$PGID $ROOT/data${RESET}"
+  fi
+fi
+
+# ---------------------------------------------------------------- 3. config -
+echo
+echo "${BOLD}${BLUE}▸ 3. gen data/config.yaml${RESET}"
+
+TMPL="config/config.yaml.tmpl"
+[ -f "$TMPL" ] || { echo "${RED}  ✗ ไม่มี $TMPL${RESET}"; exit 1; }
+
+if [ -f data/config.yaml ] && ! $FORCE; then
+  echo "${YELLOW}  ! data/config.yaml มีอยู่แล้ว — ข้าม${RESET}"
+  echo "${DIM}    เขียนทับจาก template: ./scripts/init.sh --force${RESET}"
+else
+  if [ -f data/config.yaml ]; then
+    bak="data/config.yaml.bak.$(date +%Y%m%d-%H%M%S)"
+    cp data/config.yaml "$bak"
+    echo "${DIM}  สำรองของเดิมไว้ที่ $bak${RESET}"
+  fi
+  # แทนเฉพาะตัวแปรที่ตั้งใจ — ไม่ใช้ envsubst เปล่า ๆ กัน ${...} อื่นโดนกินไปด้วย
+  # ถ้าไม่ตั้ง = ยกกลุ่มที่ผ่าน LINE_ALLOWED_GROUPS ให้ทั้งกลุ่ม (ตรงกับที่คนคาดหวัง
+  # เวลาเชิญบอทเข้ากลุ่มทีม) ตั้งเป็นรายการ group id ถ้าอยากแคบกว่านั้น
+  : "${LINE_GROUP_ALLOWED_CHATS:=${LINE_ALLOWED_GROUPS:-\"*\"}}"
+  [ -n "$LINE_GROUP_ALLOWED_CHATS" ] || LINE_GROUP_ALLOWED_CHATS='"*"'
+  LITELLM_BASE_URL="$LITELLM_BASE_URL" HERMES_MODEL="$HERMES_MODEL" \
+  HERMES_MAX_TURNS="$HERMES_MAX_TURNS" LINE_PORT="$LINE_PORT" TZ="$TZ" \
+  LINE_GROUP_ALLOWED_CHATS="$LINE_GROUP_ALLOWED_CHATS" \
+  python3 -c '
+import os, re, sys
+allowed = ("LITELLM_BASE_URL", "HERMES_MODEL", "HERMES_MAX_TURNS", "LINE_PORT", "TZ",
+           "LINE_GROUP_ALLOWED_CHATS")
+src = open(sys.argv[1], encoding="utf-8").read()
+out = re.sub(r"\$\{(\w+)\}", lambda m: os.environ[m.group(1)] if m.group(1) in allowed else m.group(0), src)
+open(sys.argv[2], "w", encoding="utf-8").write(out)
+' "$TMPL" data/config.yaml
+  chown "$PUID:$PGID" data/config.yaml 2>/dev/null || true
+  echo "${GREEN}  ok${RESET} ${DIM}(จาก $TMPL)${RESET}"
+fi
+
+# --- SOUL.md = persona ---
+# แยกจาก config.yaml เพราะ Hermes อ่านคนละไฟล์ ตัวจริงคือ data/SOUL.md
+# ที่ commit ลง repo คือ config/SOUL.md — ปรับ persona ที่นั่น
+if [ -f config/SOUL.md ]; then
+  if [ -f data/SOUL.md ] && ! $FORCE && ! cmp -s config/SOUL.md data/SOUL.md; then
+    echo "${YELLOW}  ! data/SOUL.md ต่างจาก config/SOUL.md — ข้าม (ใช้ --force ทับ)${RESET}"
+  else
+    cp config/SOUL.md data/SOUL.md
+    chown "$PUID:$PGID" data/SOUL.md 2>/dev/null || true
+    echo "${GREEN}  ok${RESET} ${DIM}data/SOUL.md ← config/SOUL.md${RESET}"
+  fi
+fi
+
+# กันพลาด: ตัวแปรที่ไม่ถูกแทนหลงเหลือ (ข้ามบรรทัด comment)
+if grep -vE '^\s*#' data/config.yaml | grep -q '\${'; then
+  echo "${RED}  ✗ ยังมี \${...} ที่ไม่ถูกแทนค้างอยู่:${RESET}"
+  grep -nE '\$\{' data/config.yaml | grep -vE '^[0-9]+:\s*#' | sed 's/^/      /'
+  exit 1
+fi
+
+# ------------------------------------------------------------- 4. litellm --
+echo
+echo "${BOLD}${BLUE}▸ 4. ตรวจทาง LiteLLM${RESET}"
+
+if docker network inspect llm-clients >/dev/null 2>&1; then
+  echo "${GREEN}  ok${RESET} ${DIM}network llm-clients มีอยู่${RESET}"
+else
+  echo "${RED}  ✗ ไม่มี docker network 'llm-clients'${RESET}"
+  echo "    docker network create llm-clients && docker network connect llm-clients llm-litellm"
+  exit 1
+fi
+
+# ยิงจากในเน็ตเวิร์กเดียวกับที่ hermes จะใช้ ไม่ใช่จาก host — จะได้เจอปัญหา DNS/route ตั้งแต่ตอนนี้
+probe=$(docker run --rm --network llm-clients curlimages/curl:latest -sS -m 20 \
+  -o /dev/null -w '%{http_code}' \
+  -H "Authorization: Bearer $LITELLM_KEY" \
+  "${LITELLM_BASE_URL%/}/models" 2>&1 || echo "conn-fail")
+case "$probe" in
+  200) echo "${GREEN}  ok${RESET} ${DIM}$LITELLM_BASE_URL/models → 200${RESET}" ;;
+  401|403) echo "${RED}  ✗ LITELLM_KEY ใช้ไม่ได้ (HTTP $probe)${RESET}"; exit 1 ;;
+  *) echo "${RED}  ✗ ต่อ $LITELLM_BASE_URL ไม่ได้ ($probe)${RESET}"
+     echo "${DIM}    เช็คว่า container llm-litellm รันอยู่: docker ps | grep litellm${RESET}"
+     exit 1 ;;
+esac
+
+# ---------------------------------------------------------------- 5. ตรวจ --
+echo
+echo "${BOLD}${BLUE}▸ 5. ให้ hermes ตรวจ config เอง${RESET}"
+
+IMG="nousresearch/hermes-agent:${HERMES_VERSION:-v2026.8.3}"
+if docker image inspect "$IMG" >/dev/null 2>&1; then
+  log="$(mktemp)"
+  docker run --rm -v "$ROOT/data:/opt/data" -e PUID="$PUID" -e PGID="$PGID" \
+    "$IMG" config check > "$log" 2>&1 || true
+  grep -E "Config version|Required|WARNING|ERROR|✗|Missing" "$log" | sed 's/^/  /' || true
+  if grep -q "WARNING\|ERROR" "$log"; then
+    echo "${YELLOW}  ! มีคำเตือน — ดูเต็ม: docker compose run --rm hermes config check${RESET}"
+  else
+    echo "${GREEN}  config ผ่าน ไม่มีคำเตือน${RESET}"
+  fi
+  rm -f "$log"
+else
+  echo "${DIM}  ยังไม่มี image — docker compose pull ก่อน${RESET}"
+fi
+
+# ---------------------------------------------------------------- สรุป -----
+echo
+echo "${BOLD}${GREEN}✓ พร้อมแล้ว${RESET}"
+echo
+echo "  ${BOLD}ขั้นต่อไป${RESET}"
+echo "    docker compose up -d                    ${DIM}# รัน gateway + LINE adapter${RESET}"
+echo "    docker compose logs -f line-bot         ${DIM}# ดูว่า LINE adapter ขึ้นไหม${RESET}"
+echo "    ./scripts/smoke-webhook.sh              ${DIM}# ยิง webhook ปลอมที่เซ็นถูก${RESET}"
+# ตัด skills ต้องรันหลัง container ขึ้นแล้ว (สคริปต์ exec เข้าไปในนั้น) จึงไม่รวมใน init
+if [ ! -f data/.no-bundled-skills ]; then
+  echo
+  echo "  ${YELLOW}ยังไม่ได้ตัด skills — bundled 71 ตัวกิน 6.7 KB ใน system prompt ทุก call${RESET}"
+  echo "    ./scripts/trim-skills.sh                ${DIM}# ตัดเหลือตาม config/skills-keep.txt${RESET}"
+fi
+if [ "$LINE_READY" = false ]; then
+  echo
+  echo "  ${YELLOW}ยังขาด LINE creds — เติมใน .env ก่อนถึงจะคุยผ่าน LINE ได้${RESET}"
+fi
+echo

--- a/templates/bot-service-hermes/scripts/probe-litellm.sh
+++ b/templates/bot-service-hermes/scripts/probe-litellm.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Probe: โมเดลไหนใน LiteLLM gateway รับ Hermes ไหว
+#
+# Hermes ยิง ~13.5K tokens ทุก call และวิ่งด้วย tool loop ล้วน ๆ
+# เกณฑ์ผ่านจึงมี 3 ข้อ ต้องผ่านครบ:
+#   1. tool_calls กลับมาเป็น field จริง ไม่ใช่ <tool_call> ปนใน content
+#   2. รับ prompt ~14K tokens ได้ ไม่ 429/413
+#   3. ตอบไทยรู้เรื่อง
+#
+#   ./scripts/probe-litellm.sh                 # ยิงชุด default
+#   ./scripts/probe-litellm.sh or/ox-alpha ... # ระบุเอง
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+BASE="${LITELLM_BASE_URL:-http://127.0.0.1:4000/v1}"   # ยิงจาก host จึงใช้ 127.0.0.1
+KEY="${LITELLM_KEY:-}"
+if [[ -z "$KEY" && -f .env ]]; then
+  KEY=$(grep -E '^LITELLM_KEY=' .env | cut -d= -f2- || true)
+fi
+# ไม่ fallback ไปหยิบ LITELLM_MASTER_KEY โดยตั้งใจ — master key เป็น admin ของ
+# ทั้ง gateway (ออก/เพิกถอน key คนอื่น ดู spend ทุกใบ ข้าม budget) ต้องใช้ virtual key
+[[ -n "$KEY" ]] || { echo "ไม่มี LITELLM_KEY ใน .env — ออก virtual key จาก LiteLLM ก่อน" >&2; exit 1; }
+
+# ตัวที่ context ใหญ่พอสำหรับ Hermes — แก้ให้ตรงกับโมเดลที่ gateway ของคุณมี
+DEFAULT_MODELS=(
+  or/nemotron-ultra-550b   # 1M ctx
+  or/ox-alpha              # 1M ctx
+  or/dots-3-note           # 512K ctx
+  or/nemotron-super-120b   # 262K
+  or/gemma-4-31b           # 262K
+  oc/nemotron-3-ultra
+  oc/gpt-oss-120b
+  gq/gpt-oss-120b
+  nim/deepseek-v4-flash
+  mi/large
+  cb/gpt-oss-120b
+  or/auto-free
+)
+MODELS=("${@:-}")
+[[ -z "${MODELS[0]:-}" ]] && MODELS=("${DEFAULT_MODELS[@]}")
+
+mkdir -p results
+printf '%-24s %-6s %-7s %-9s %s\n' MODEL TOOLS BIG-CTX TIME NOTE
+printf '%.0s-' {1..78}; echo
+
+for m in "${MODELS[@]}"; do
+  BASE="$BASE" KEY="$KEY" MODEL="$m" python3 - <<'PY'
+import json, os, time, urllib.request, urllib.error
+
+base, key, model = os.environ["BASE"], os.environ["KEY"], os.environ["MODEL"]
+
+def call(payload, timeout=180):
+    req = urllib.request.Request(
+        base.rstrip("/") + "/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Authorization": "Bearer " + key, "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace")[:200]
+        return e.code, {"_raw": body}
+    except Exception as e:
+        return 0, {"_raw": f"{type(e).__name__}: {e}"[:200]}
+
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "run_shell",
+        "description": "รันคำสั่ง shell แล้วคืน stdout",
+        "parameters": {
+            "type": "object",
+            "properties": {"cmd": {"type": "string"}},
+            "required": ["cmd"],
+        },
+    },
+}]
+
+# --- 1) tool calling + ภาษาไทย ---------------------------------------------
+t0 = time.time()
+st, body = call({
+    "model": model,
+    "messages": [
+        {"role": "system", "content": "คุณเป็นผู้ช่วยที่ตอบเป็นภาษาไทย เรียกใช้ tool เมื่อจำเป็น"},
+        {"role": "user", "content": "ช่วยดูหน่อยว่าในโฟลเดอร์ /tmp มีไฟล์อะไรบ้าง"},
+    ],
+    "tools": TOOLS,
+    "max_tokens": 512,
+})
+elapsed = time.time() - t0
+
+tools_ok, note = "no", ""
+if st != 200:
+    note = f"HTTP {st}: {str(body.get('_raw', body))[:60]}"
+elif not body.get("choices"):
+    note = "ไม่มี choices: " + json.dumps(body)[:60]
+else:
+    msg = body["choices"][0].get("message") or {}
+    content = msg.get("content") or ""
+    if msg.get("tool_calls"):
+        tools_ok = "YES"
+    elif "<tool_call>" in content or '"name"' in content and "run_shell" in content:
+        tools_ok = "text"          # พ่น tool call ปนใน text — Hermes ใช้ไม่ได้
+        note = "tool call ปนใน content"
+    else:
+        note = "ไม่เรียก tool: " + content.replace("\n", " ")[:50]
+
+# --- 2) prompt ใหญ่ ~14K tokens (พื้นของ Hermes ทุก call) -------------------
+big = "บรรทัดที่ %d: ข้อมูลตัวอย่างสำหรับวัดว่า context รับไหวไหม\n"
+filler = "".join(big % i for i in range(1400))     # ~14K tokens
+bst, bbody = call({
+    "model": model,
+    "messages": [
+        {"role": "system", "content": filler},
+        {"role": "user", "content": "ตอบสั้น ๆ ว่า 'รับได้' ถ้าคุณอ่านข้อความข้างบนครบ"},
+    ],
+    "tools": TOOLS,
+    "max_tokens": 64,
+}, timeout=240)
+big_ok = "YES" if bst == 200 and bbody.get("choices") else "no"
+if big_ok == "no" and not note:
+    note = f"ctx {bst}: {str(bbody.get('_raw', bbody))[:50]}"
+
+print("%-24s %-6s %-7s %-9s %s" % (model, tools_ok, big_ok, f"{elapsed:.1f}s", note))
+PY
+done

--- a/templates/bot-service-hermes/scripts/probe-thai.sh
+++ b/templates/bot-service-hermes/scripts/probe-thai.sh
@@ -51,17 +51,34 @@ printf '%-22s %-6s %s\n' MODEL ไทย ผล
 printf '%.0s-' {1..72}; echo
 
 for m in "${MODELS[@]}"; do
-  marks=""; thai_n=0; slow_n=0; err_n=0
+  marks=""; thai_n=0; slow_n=0; err_n=0; wrong_n=0; wrong_detail=""
   for _ in $(seq 1 "$ROUNDS"); do
     # ⚠️ แยก "เราตัดสายเอง" ออกจาก "โมเดลพัง" — timeout คืน exit code 124
     #    เคยรายงาน mi/magistral-medium เป็น "พัง 0/3" ทั้งที่มันตอบไทยได้ปกติ
     #    แค่ใช้ 146-227s ต่อ turn ซึ่งชน timeout เดิมที่ตั้งไว้ 240s
     #    ถ้าไม่แยกจะอ่านผลผิดว่าโมเดลใช้ไม่ได้
+    # 🔴 Hermes มี fallback_providers ของตัวเอง — ถ้าโมเดลที่ขอตาย มันไล่ไปตัวถัดไป
+    #    "เงียบ ๆ" แล้วเราจะวัดภาษาของตัวสำรองใส่ชื่อตัวที่ขอ
+    #    (บทเรียนจาก llm-gateway: latency_ms_14k รอบแรกผิด 11 ตัวเพราะเรื่องนี้)
+    #
+    #    ยิงผ่าน CLI จึงใส่ disable_fallbacks ใน request เองไม่ได้ และ CLI ก็ไม่เขียน
+    #    "API call #" ลง agent.log ของ gateway ด้วย — ใช้ --usage-file แทน
+    #    ซึ่งบันทึก "model" ที่ตอบจริงไว้ ตรวจได้แน่นอน
+    UF=/tmp/probe-thai-usage.json
+    docker exec "$CONTAINER" rm -f "$UF" 2>/dev/null
     out=$(timeout "$TIMEOUT" docker exec "$CONTAINER" /opt/hermes/.venv/bin/hermes \
-      -z "$PROMPT" -m "$m" --provider custom:litellm --yolo 2>&1)
+      -z "$PROMPT" -m "$m" --provider custom:litellm --usage-file "$UF" --yolo 2>&1)
     rc=$?
     if [ "$rc" = 124 ]; then
       marks="$marks${YELLOW}ช้า>${TIMEOUT}s${RESET} "; slow_n=$((slow_n+1)); continue
+    fi
+    answered=$(docker exec "$CONTAINER" sh -c "cat $UF 2>/dev/null" \
+      | python3 -c 'import sys,json
+try: print(json.load(sys.stdin).get("model",""))
+except Exception: print("")' 2>/dev/null)
+    if [ -n "$answered" ] && [ "$answered" != "$m" ]; then
+      marks="$marks${RED}วัดผิด${RESET} "; wrong_n=$((wrong_n+1)); wrong_detail="$answered"
+      continue
     fi
     lang=$(OUT="$out" python3 "$LANG_PY")
     case "$lang" in
@@ -74,7 +91,8 @@ for m in "${MODELS[@]}"; do
   score="$thai_n/$ROUNDS"
   note=""
   [ "$slow_n" -gt 0 ] && note="ช้าเกิน ${TIMEOUT}s $slow_n ครั้ง "
-  [ "$err_n" -gt 0 ] && note="${note}error $err_n ครั้ง"
+  [ "$err_n" -gt 0 ] && note="${note}error $err_n ครั้ง "
+  [ "$wrong_n" -gt 0 ] && note="${note}🔴 fallback ไปตอบแทน $wrong_n ครั้ง ($wrong_detail)"
   printf '%-22s %-6s %b%s\n' "$m" "$score" "$marks" "${DIM}${note}${RESET}"
 done
 echo

--- a/templates/bot-service-hermes/scripts/probe-thai.sh
+++ b/templates/bot-service-hermes/scripts/probe-thai.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ============================================================================
+# probe-thai.sh — โมเดลไหน "อยู่กับภาษาไทย" ได้ตอนวิ่ง tool loop จริง
+#
+# ทำไมต้องมีสคริปต์นี้แยกจาก probe-litellm.sh:
+#   probe-litellm.sh ทดสอบด้วยการยิง API ตรง ๆ 2 turn — โมเดลตอบไทยผ่านหมด
+#   แต่พอรันใน Hermes จริง (system prompt อังกฤษ 16 KB + ผล tool เป็นอังกฤษ
+#   ล้วน ๆ ในบริบท) โมเดลบางตัว "ไหล" ไปตอบอังกฤษหรือจีนแทน
+#   ต้องวัดในสภาพจริงเท่านั้นถึงจะเห็น
+#
+#   ./scripts/probe-thai.sh                      # ชุด default 3 รอบต่อโมเดล
+#   ./scripts/probe-thai.sh -n 5 mi/large        # ระบุเอง
+# ============================================================================
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+GREEN=$'\033[0;32m'; RED=$'\033[0;31m'; YELLOW=$'\033[0;33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+
+# ⚠️ scripts ไม่ถูกแทน {{PLACEHOLDER}} ตอน `botforge new` (sed ทำเฉพาะ
+#    *.yml *.yaml *.json *.md *.ts *.js *.example *.toml) — ชื่อ container
+#    จึงต้องมาจาก CONTAINER_PREFIX ใน .env เท่านั้น
+[ -f .env ] && { set -a; . ./.env; set +a; }
+: "${CONTAINER_PREFIX:?ไม่มี CONTAINER_PREFIX ใน .env — คัดลอกจาก .env.example}"
+CONTAINER="${CONTAINER_PREFIX}-line-bot"
+
+ROUNDS=3
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    -n) ROUNDS="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+MODELS=("$@")
+[ "${#MODELS[@]}" -gt 0 ] || MODELS=(oc/gpt-oss-120b mi/large or/ox-alpha cb/gpt-oss-120b oc/nemotron-3-ultra)
+
+docker ps --format '{{.Names}}' | grep -qx "$CONTAINER" || {
+  echo "${RED}✗ container $CONTAINER ไม่ได้รัน${RESET}" >&2; exit 1; }
+
+# โจทย์ต้องบังคับให้ "ใช้ tool" — ผล tool เป็นอังกฤษล้วนคือตัวที่ทำให้โมเดลไหล
+PROMPT="สรุปให้หน่อยว่าในโฟลเดอร์ /opt/data/logs มีไฟล์อะไรบ้าง และแต่ละอันน่าจะเก็บอะไร"
+
+echo "${DIM}โจทย์: $PROMPT${RESET}"
+echo "${DIM}รอบละโมเดล: $ROUNDS${RESET}"
+echo
+printf '%-22s %-6s %s\n' MODEL ไทย ผล
+printf '%.0s-' {1..72}; echo
+
+for m in "${MODELS[@]}"; do
+  marks=""; thai_n=0
+  for _ in $(seq 1 "$ROUNDS"); do
+    out=$(timeout 240 docker exec "$CONTAINER" /opt/hermes/.venv/bin/hermes \
+      -z "$PROMPT" -m "$m" --provider custom:litellm --yolo 2>&1)
+    lang=$(OUT="$out" python3 scripts/_lang.py)
+    case "$lang" in
+      th) marks="$marks${GREEN}ไทย${RESET} "; thai_n=$((thai_n+1)) ;;
+      zh) marks="$marks${RED}จีน${RESET} " ;;
+      en) marks="$marks${YELLOW}อังกฤษ${RESET} " ;;
+      *)  marks="$marks${RED}พัง${RESET} " ;;
+    esac
+  done
+  score="$thai_n/$ROUNDS"
+  printf '%-22s %-6s %b\n' "$m" "$score" "$marks"
+done
+echo
+echo "${DIM}เกณฑ์: ตัวที่จะใช้เป็น main ต้องได้เต็ม — บอทไทยที่ตอบอังกฤษบ้างใช้งานจริงไม่ได้${RESET}"

--- a/templates/bot-service-hermes/scripts/probe-thai.sh
+++ b/templates/bot-service-hermes/scripts/probe-thai.sh
@@ -9,7 +9,8 @@
 #   ต้องวัดในสภาพจริงเท่านั้นถึงจะเห็น
 #
 #   ./scripts/probe-thai.sh                      # ชุด default 3 รอบต่อโมเดล
-#   ./scripts/probe-thai.sh -n 5 mi/large        # ระบุเอง
+#   ./scripts/probe-thai.sh -n 5 mi/large        # ระบุจำนวนรอบ + โมเดล
+#   ./scripts/probe-thai.sh -t 600 mi/magistral-medium   # ยืด timeout ให้ตัวที่ช้า
 # ============================================================================
 set -uo pipefail
 cd "$(dirname "$0")/.."
@@ -24,9 +25,13 @@ GREEN=$'\033[0;32m'; RED=$'\033[0;31m'; YELLOW=$'\033[0;33m'; DIM=$'\033[2m'; RE
 CONTAINER="${CONTAINER_PREFIX}-line-bot"
 
 ROUNDS=3
+# ตั้งสูงไว้ก่อน — reasoning model บางตัวใช้ 200s+ ต่อ turn ตัดสายเร็วไปจะอ่านผลผิด
+TIMEOUT="${PROBE_TIMEOUT:-400}"
+LANG_PY="$(dirname "$0")/_lang.py"
 while [[ "${1:-}" == -* ]]; do
   case "$1" in
     -n) ROUNDS="$2"; shift 2 ;;
+    -t) TIMEOUT="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 1 ;;
   esac
 done
@@ -46,20 +51,31 @@ printf '%-22s %-6s %s\n' MODEL ไทย ผล
 printf '%.0s-' {1..72}; echo
 
 for m in "${MODELS[@]}"; do
-  marks=""; thai_n=0
+  marks=""; thai_n=0; slow_n=0; err_n=0
   for _ in $(seq 1 "$ROUNDS"); do
-    out=$(timeout 240 docker exec "$CONTAINER" /opt/hermes/.venv/bin/hermes \
+    # ⚠️ แยก "เราตัดสายเอง" ออกจาก "โมเดลพัง" — timeout คืน exit code 124
+    #    เคยรายงาน mi/magistral-medium เป็น "พัง 0/3" ทั้งที่มันตอบไทยได้ปกติ
+    #    แค่ใช้ 146-227s ต่อ turn ซึ่งชน timeout เดิมที่ตั้งไว้ 240s
+    #    ถ้าไม่แยกจะอ่านผลผิดว่าโมเดลใช้ไม่ได้
+    out=$(timeout "$TIMEOUT" docker exec "$CONTAINER" /opt/hermes/.venv/bin/hermes \
       -z "$PROMPT" -m "$m" --provider custom:litellm --yolo 2>&1)
-    lang=$(OUT="$out" python3 scripts/_lang.py)
+    rc=$?
+    if [ "$rc" = 124 ]; then
+      marks="$marks${YELLOW}ช้า>${TIMEOUT}s${RESET} "; slow_n=$((slow_n+1)); continue
+    fi
+    lang=$(OUT="$out" python3 "$LANG_PY")
     case "$lang" in
       th) marks="$marks${GREEN}ไทย${RESET} "; thai_n=$((thai_n+1)) ;;
       zh) marks="$marks${RED}จีน${RESET} " ;;
       en) marks="$marks${YELLOW}อังกฤษ${RESET} " ;;
-      *)  marks="$marks${RED}พัง${RESET} " ;;
+      *)  marks="$marks${RED}พัง${RESET} "; err_n=$((err_n+1)) ;;
     esac
   done
   score="$thai_n/$ROUNDS"
-  printf '%-22s %-6s %b\n' "$m" "$score" "$marks"
+  note=""
+  [ "$slow_n" -gt 0 ] && note="ช้าเกิน ${TIMEOUT}s $slow_n ครั้ง "
+  [ "$err_n" -gt 0 ] && note="${note}error $err_n ครั้ง"
+  printf '%-22s %-6s %b%s\n' "$m" "$score" "$marks" "${DIM}${note}${RESET}"
 done
 echo
 echo "${DIM}เกณฑ์: ตัวที่จะใช้เป็น main ต้องได้เต็ม — บอทไทยที่ตอบอังกฤษบ้างใช้งานจริงไม่ได้${RESET}"

--- a/templates/bot-service-hermes/scripts/smoke-webhook.sh
+++ b/templates/bot-service-hermes/scripts/smoke-webhook.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ============================================================================
+# smoke-webhook.sh — ยิง webhook ปลอมที่ "เซ็นถูก" เข้า LINE adapter
+#
+# ใช้พิสูจน์ทั้งเส้นทางโดยไม่ต้องมี LINE OA จริง: ลายเซ็น → allowlist →
+# session → โมเดล  ตัวที่เหลือให้ LINE ทำจริงคือ "การส่งกลับ" เท่านั้น
+# (reply token ปลอมจะได้ 400 จาก api.line.me เป็นเรื่องปกติ)
+#
+#   ./scripts/smoke-webhook.sh                       # เป็นแชทส่วนตัว
+#   ./scripts/smoke-webhook.sh --group               # เป็นข้อความในกลุ่ม
+#   ./scripts/smoke-webhook.sh --room                # เป็นข้อความในห้อง
+#   ./scripts/smoke-webhook.sh -m "สวัสดี ทำอะไรได้บ้าง"
+#   ./scripts/smoke-webhook.sh --bad-sig             # ต้องได้ 401
+# ============================================================================
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+GREEN=$'\033[0;32m'; RED=$'\033[0;31m'; YELLOW=$'\033[0;33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+
+[ -f .env ] || { echo "ไม่มี .env" >&2; exit 1; }
+set -a; . ./.env; set +a
+
+: "${LINE_PORT:=8646}"
+: "${CONTAINER_PREFIX:?ไม่มี CONTAINER_PREFIX ใน .env}"
+: "${BIND_ADDR:=127.0.0.1}"
+: "${LINE_WEBHOOK_PATH:=/line/webhook}"
+# botforge ไม่ publish port ออก host (ทางเข้าเดียวคือ cloudflared) — ยิงจาก
+# ในเน็ตเวิร์กของ compose แทน  ถ้า project ไหน publish port ไว้ ตั้ง
+# SMOKE_VIA_HOST=1 แล้วมันจะยิง http://127.0.0.1:<port> ตรง ๆ เหมือนเดิม
+if [ "${SMOKE_VIA_HOST:-0}" = "1" ]; then
+  URL="http://${BIND_ADDR}:${LINE_PORT}${LINE_WEBHOOK_PATH:-/line/webhook}"
+  VIA_NET=""
+else
+  URL="http://${CONTAINER_PREFIX}-line-bot:${LINE_PORT}${LINE_WEBHOOK_PATH:-/line/webhook}"
+  VIA_NET=$(docker inspect "${CONTAINER_PREFIX}-line-bot" \
+    --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{"\n"}}{{end}}' 2>/dev/null | head -1)
+  [ -n "$VIA_NET" ] || { echo "หา network ของ ${CONTAINER_PREFIX}-line-bot ไม่เจอ — container ขึ้นหรือยัง" >&2; exit 1; }
+fi
+
+SRC=user; TEXT="สวัสดี ช่วยบอกหน่อยว่าตอนนี้เป็นเวลาอะไร"; BAD_SIG=false; FORCE_ID=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --group) SRC=group; shift ;;
+    --room)  SRC=room;  shift ;;
+    --bad-sig) BAD_SIG=true; shift ;;
+    -m|--message) TEXT="$2"; shift 2 ;;
+    --id) FORCE_ID="$2"; shift 2 ;;   # ยิงด้วย id ที่กำหนดเอง — ใช้ทดสอบว่า allowlist กันจริง
+    -u|--url) URL="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# id ที่ใช้ยิงต้องอยู่ใน allowlist ไม่งั้น adapter ตีตกเงียบ ๆ (ตอบ 200 แต่ไม่ทำอะไร)
+pick() { echo "$1" | cut -d, -f1 | tr -d ' '; }
+case "$SRC" in
+  user)  ID="$(pick "${LINE_ALLOWED_USERS:-}")";  ID="${ID:-Usmoketest0000000000000000000000}"; SRC_JSON="{\"type\":\"user\",\"userId\":\"$ID\"}" ;;
+  group) GID="$(pick "${LINE_ALLOWED_GROUPS:-}")"; GID="${GID:-Csmoketest0000000000000000000000}"
+         UID_="$(pick "${LINE_ALLOWED_USERS:-}")"; UID_="${UID_:-Usmoketest0000000000000000000000}"
+         ID="$GID"; SRC_JSON="{\"type\":\"group\",\"groupId\":\"$GID\",\"userId\":\"$UID_\"}" ;;
+  room)  RID="$(pick "${LINE_ALLOWED_ROOMS:-}")"; RID="${RID:-Rsmoketest0000000000000000000000}"
+         UID_="$(pick "${LINE_ALLOWED_USERS:-}")"; UID_="${UID_:-Usmoketest0000000000000000000000}"
+         ID="$RID"; SRC_JSON="{\"type\":\"room\",\"roomId\":\"$RID\",\"userId\":\"$UID_\"}" ;;
+esac
+
+# --id ทับค่าที่หยิบจาก allowlist — ต้องทำหลัง case เพราะ .env ถูก source ไปแล้ว
+if [ -n "$FORCE_ID" ]; then
+  ID="$FORCE_ID"
+  case "$SRC" in
+    user)  SRC_JSON="{\"type\":\"user\",\"userId\":\"$ID\"}" ;;
+    group) SRC_JSON="{\"type\":\"group\",\"groupId\":\"$ID\",\"userId\":\"$ID\"}" ;;
+    room)  SRC_JSON="{\"type\":\"room\",\"roomId\":\"$ID\",\"userId\":\"$ID\"}" ;;
+  esac
+fi
+
+if [ "${LINE_ALLOW_ALL_USERS:-false}" != "true" ]; then
+  case "$SRC" in
+    user)  [ -n "${LINE_ALLOWED_USERS:-}" ]  || echo "${YELLOW}! LINE_ALLOWED_USERS ว่าง — adapter จะตีตก${RESET}" ;;
+    group) [ -n "${LINE_ALLOWED_GROUPS:-}" ] || echo "${YELLOW}! LINE_ALLOWED_GROUPS ว่าง — adapter จะตีตก${RESET}" ;;
+    room)  [ -n "${LINE_ALLOWED_ROOMS:-}" ]  || echo "${YELLOW}! LINE_ALLOWED_ROOMS ว่าง — adapter จะตีตก${RESET}" ;;
+  esac
+fi
+
+# webhookEventId ต้องไม่ซ้ำ ไม่งั้นโดน dedup ทิ้ง
+EVT="smoke$(date +%s%N | tail -c 12)"
+BODY=$(SRC_JSON="$SRC_JSON" TEXT="$TEXT" EVT="$EVT" python3 - <<'PY'
+import json, os, time
+print(json.dumps({
+    "destination": "Ufakedestination0000000000000000",
+    "events": [{
+        "type": "message",
+        "mode": "active",
+        "webhookEventId": os.environ["EVT"],
+        "deliveryContext": {"isRedelivery": False},
+        "timestamp": int(time.time() * 1000),
+        "source": json.loads(os.environ["SRC_JSON"]),
+        "replyToken": "smoke-reply-token-not-real",
+        "message": {"type": "text", "id": os.environ["EVT"], "text": os.environ["TEXT"]},
+    }],
+}, ensure_ascii=False, separators=(",", ":")))
+PY
+)
+
+# ลายเซ็น = base64( HMAC-SHA256( channel_secret, raw_body ) )  — ต้องเซ็น "ไบต์ที่ส่งจริง"
+if $BAD_SIG; then
+  SIG="ZmFrZS1zaWduYXR1cmUtdmFsdWU="
+else
+  [ -n "${LINE_CHANNEL_SECRET:-}" ] || { echo "${RED}✗ LINE_CHANNEL_SECRET ว่าง — เซ็นไม่ได้${RESET}" >&2; exit 1; }
+  SIG=$(SECRET="$LINE_CHANNEL_SECRET" BODY="$BODY" python3 -c '
+import base64, hashlib, hmac, os
+print(base64.b64encode(hmac.new(os.environ["SECRET"].encode(),
+      os.environ["BODY"].encode(), hashlib.sha256).digest()).decode())')
+fi
+
+echo "${DIM}POST $URL  (source=$SRC id=$ID)${RESET}"
+echo "${DIM}  ข้อความ: $TEXT${RESET}"
+t0=$(date +%s%N)
+if [ -n "$VIA_NET" ]; then
+  code=$(docker run --rm --network "$VIA_NET" -i curlimages/curl:latest \
+    -sS -o /dev/null -w '%{http_code}' -m 30 \
+    -X POST "$URL" \
+    -H "Content-Type: application/json" \
+    -H "X-Line-Signature: $SIG" \
+    --data-raw "$BODY") || { echo "${RED}✗ ต่อไม่ได้ (network $VIA_NET)${RESET}"; exit 1; }
+else
+  code=$(curl -sS -o /tmp/botforge-hermes-smoke.out -w '%{http_code}' -m 30 \
+    -X POST "$URL" \
+    -H "Content-Type: application/json" \
+    -H "X-Line-Signature: $SIG" \
+    --data-raw "$BODY") || { echo "${RED}✗ ต่อไม่ได้ — container ขึ้นหรือยัง${RESET}"; exit 1; }
+fi
+ms=$(( ($(date +%s%N) - t0) / 1000000 ))
+
+echo
+if $BAD_SIG; then
+  # adapter คืน 401 "invalid signature" (adapter.py:952) — ไม่ใช่ 403
+  # 403 สงวนไว้ให้ media endpoint ที่กัน path traversal (adapter.py:1418)
+  if [ "$code" = "401" ]; then
+    echo "${GREEN}✓ signature ผิด → 401 ถูกต้อง${RESET} ${DIM}(${ms}ms)${RESET}"
+  else
+    echo "${RED}✗ signature ผิดแต่ได้ $code — ควรเป็น 401${RESET}"; exit 1
+  fi
+elif [ "$code" = "200" ]; then
+  echo "${GREEN}✓ 200 OK${RESET} ${DIM}(${ms}ms — adapter รับแล้ว ตอบทันทีไม่รอโมเดล)${RESET}"
+  echo
+  echo "  ${DIM}คำตอบจริงไปโผล่ใน log (reply token ปลอม ส่งกลับ LINE ไม่ได้):${RESET}"
+  echo "  docker compose logs --tail 60 hermes"
+else
+  echo "${RED}✗ HTTP $code${RESET}"; cat /tmp/botforge-hermes-smoke.out 2>/dev/null; exit 1
+fi

--- a/templates/bot-service-hermes/scripts/trim-skills.sh
+++ b/templates/bot-service-hermes/scripts/trim-skills.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# ============================================================================
+# trim-skills.sh — ตัด bundled skills เหลือเท่าที่อยู่ใน config/skills-keep.txt
+#
+#   ./scripts/trim-skills.sh                    # ตัดตาม keep-list
+#   ./scripts/trim-skills.sh --list-available   # ดูรายชื่อทั้งหมดที่เลือกได้
+#   ./scripts/trim-skills.sh --restore          # เอา 71 ตัวกลับมาทั้งหมด
+#
+# ทำไมต้องมีสคริปต์ ไม่ลบมือ:
+#   container sync bundled skills กลับเข้า /opt/data/skills ทุกครั้งที่ boot
+#   ("Done: 0 new, 0 updated, 71 unchanged") ลบมือแล้วมันกลับมาเอง
+#   ตัวที่หยุด sync คือ marker /opt/data/.no-bundled-skills — สคริปต์นี้เขียนให้
+#   (tools/skills_sync.py:688 เช็ค marker ก่อนทำอะไรทั้งสิ้น)
+#
+# skills ที่ copy กลับมาหลังตั้ง marker จะถูกมองเป็น local skill ไม่ใช่ bundled
+# จึงอยู่รอดข้าม restart และข้าม `hermes update`
+# ============================================================================
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+GREEN=$'\033[0;32m'; RED=$'\033[0;31m'; YELLOW=$'\033[0;33m'
+BLUE=$'\033[0;34m'; DIM=$'\033[2m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+
+KEEP_FILE="config/skills-keep.txt"
+# ⚠️ scripts ไม่ถูกแทน {{PLACEHOLDER}} ตอน `botforge new` (sed ทำเฉพาะ
+#    *.yml *.yaml *.json *.md *.ts *.js *.example *.toml) — ชื่อ container
+#    จึงต้องมาจาก CONTAINER_PREFIX ใน .env เท่านั้น
+[ -f .env ] && { set -a; . ./.env; set +a; }
+: "${CONTAINER_PREFIX:?ไม่มี CONTAINER_PREFIX ใน .env — คัดลอกจาก .env.example}"
+CONTAINER="${CONTAINER_PREFIX}-line-bot"
+: "${PUID:=$(id -u)}"; : "${PGID:=$(id -g)}"
+
+running() { docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; }
+
+if [ "${1:-}" = "--list-available" ]; then
+  running || { echo "${RED}✗ container $CONTAINER ไม่ได้รัน${RESET}" >&2; exit 1; }
+  docker exec "$CONTAINER" sh -c 'cd /opt/hermes/skills && for c in */; do
+      [ "$c" = "index-cache/" ] && continue
+      for s in "$c"*/; do [ -d "$s" ] && echo "${s%/}"; done
+    done' | sort
+  exit 0
+fi
+
+if [ "${1:-}" = "--restore" ]; then
+  echo "${BOLD}${BLUE}▸ เอา bundled skills กลับมาทั้งหมด${RESET}"
+  rm -f data/.no-bundled-skills
+  running && docker exec "$CONTAINER" /opt/hermes/.venv/bin/hermes skills opt-in >/dev/null 2>&1 || true
+  echo "${GREEN}  ลบ marker แล้ว — restart แล้ว container จะ sync 71 ตัวกลับเอง${RESET}"
+  echo "${DIM}  docker compose restart line-bot${RESET}"
+  exit 0
+fi
+
+[ -f "$KEEP_FILE" ] || { echo "${RED}✗ ไม่มี $KEEP_FILE${RESET}" >&2; exit 1; }
+running || { echo "${RED}✗ container $CONTAINER ไม่ได้รัน — docker compose up -d ก่อน${RESET}" >&2; exit 1; }
+
+mapfile -t KEEP < <(grep -vE '^\s*#|^\s*$' "$KEEP_FILE" | tr -d ' \r')
+[ "${#KEEP[@]}" -gt 0 ] || { echo "${RED}✗ keep-list ว่าง${RESET}" >&2; exit 1; }
+
+# ตรวจก่อนลบว่าทุกตัวใน keep-list มีอยู่จริง — พิมพ์ผิดแล้วลบทิ้งหมดจะเจ็บ
+echo
+echo "${BOLD}${BLUE}▸ 1. ตรวจ keep-list (${#KEEP[@]} ตัว)${RESET}"
+bad=0
+for s in "${KEEP[@]}"; do
+  if docker exec "$CONTAINER" test -f "/opt/hermes/skills/$s/SKILL.md" 2>/dev/null; then
+    echo "${GREEN}  ✓${RESET} $s"
+  else
+    echo "${RED}  ✗ ไม่มี $s ใน /opt/hermes/skills${RESET}"; bad=1
+  fi
+done
+[ "$bad" = 0 ] || { echo "${RED}✗ หยุด — แก้ $KEEP_FILE ก่อน (ดูรายชื่อ: --list-available)${RESET}"; exit 1; }
+
+before=$(docker exec "$CONTAINER" sh -c 'ls -d /opt/data/skills/*/*/ 2>/dev/null | wc -l' || echo 0)
+
+# ------------------------------------------------------------------ ตัด ---
+echo
+echo "${BOLD}${BLUE}▸ 2. ตั้ง marker + ลบ bundled skills ที่ไม่ได้แก้เอง${RESET}"
+docker exec "$CONTAINER" /opt/hermes/.venv/bin/hermes skills opt-out --remove --yes 2>&1 \
+  | grep -viE '^\s*$' | tail -5 | sed 's/^/  /' || true
+
+# --- กวาดที่ opt-out ไม่แตะ ---
+# `opt-out --remove` ลบเฉพาะ bundled ที่ไม่ได้แก้เอง — "official optional"
+# skills (ตัวที่มีทั้งใน skills/ และ optional-skills/ เช่น mlops/inference,
+# mlops/models) รอดมาเสมอ  keep-list ต้องเป็นตัวตัดสินสุดท้าย จึงกวาดซ้ำเอง
+echo
+echo "${BOLD}${BLUE}▸ 2b. กวาดตัวที่ opt-out ไม่แตะ${RESET}"
+swept=0
+while read -r d; do
+  [ -n "$d" ] || continue
+  for k in "${KEEP[@]}"; do [ "$k" = "$d" ] && continue 2; done
+  docker exec "$CONTAINER" rm -rf "/opt/data/skills/$d"
+  echo "${YELLOW}  −${RESET} $d ${DIM}(official optional — opt-out ไม่ลบให้)${RESET}"
+  swept=$((swept+1))
+done < <(docker exec "$CONTAINER" find /opt/data/skills -mindepth 2 -maxdepth 2 -type d \
+  -printf '%P\n' 2>/dev/null || true)
+[ "$swept" = 0 ] && echo "${DIM}  ไม่มีตัวตกค้าง${RESET}"
+
+# --------------------------------------------------------------- copy กลับ -
+echo
+echo "${BOLD}${BLUE}▸ 3. copy เฉพาะตัวใน keep-list กลับเข้า /opt/data/skills${RESET}"
+for s in "${KEEP[@]}"; do
+  # ลบปลายทางก่อน — cp -a src dest ตอน dest มีอยู่แล้วจะได้ dest/<ชื่อ>/<ชื่อ> ซ้อนกัน
+  # (เจอจริงตอนรันสคริปต์ซ้ำรอบสอง: skills index โตจาก 835 B เป็น 1,387 B)
+  docker exec "$CONTAINER" sh -c "
+    rm -rf '/opt/data/skills/$s' &&
+    mkdir -p '/opt/data/skills/$(dirname "$s")' &&
+    cp -a '/opt/hermes/skills/$s' '/opt/data/skills/$s'" 2>&1 | sed 's/^/  /'
+  echo "${GREEN}  +${RESET} $s"
+done
+
+# DESCRIPTION.md ของหมวด — ไม่ใช่ skill แต่ index อ่านเพื่อจัดกลุ่ม
+for c in $(printf '%s\n' "${KEEP[@]}" | cut -d/ -f1 | sort -u); do
+  docker exec "$CONTAINER" sh -c "
+    [ -f /opt/hermes/skills/$c/DESCRIPTION.md ] &&
+    cp -a /opt/hermes/skills/$c/DESCRIPTION.md /opt/data/skills/$c/ || true" 2>/dev/null || true
+done
+
+after=$(docker exec "$CONTAINER" sh -c 'ls -d /opt/data/skills/*/*/ 2>/dev/null | wc -l' || echo 0)
+
+# ------------------------------------------------------------------ วัด ---
+echo
+echo "${BOLD}${BLUE}▸ 4. วัดผล${RESET}"
+echo "${DIM}  skills: $before → $after${RESET}"
+docker exec "$CONTAINER" /opt/hermes/.venv/bin/hermes prompt-size 2>/dev/null \
+  | grep -E "System prompt total|skills index|Tool schemas" | sed 's/^/  /' || true
+
+echo
+echo "${GREEN}✓ เสร็จ${RESET} ${DIM}— restart เพื่อให้ gateway โหลด index ใหม่:${RESET}"
+echo "  docker compose restart line-bot"


### PR DESCRIPTION
## ทำอะไร

เพิ่ม engine ตัวที่ 10 — **hermes** ([Hermes Agent](https://hub.docker.com/r/nousresearch/hermes-agent))
เป็น engine ตัวแรกที่ **เป็นเจ้าของ LINE channel เอง**

```
engine อื่น:  LINE ──► botforge line-bot ──► engine server
              (bun + @line/bot-sdk ~1,300 บรรทัด)

hermes:       LINE ──► hermes (มี LINE adapter ในตัว 1,758 บรรทัด)
```

`plugins/platforms/line/adapter.py` ที่มากับ image ทำให้แล้วทั้งลายเซ็น HMAC-SHA256,
dedup `webhookEventId`, กันบอทตอบตัวเอง, allowlist 3 ชั้น (user/group/room),
reply token ก่อนค่อย Push, ปุ่ม postback ตอนตอบช้าเกิน 45s, ตัดข้อความยาวเป็นหลาย bubble,
รับรูป/เสียง/วิดีโอ/ไฟล์

**เทมเพลตจึงไม่มี `src/` `Dockerfile` `package.json`** — มีแต่ config

## ทำไมยังชื่อ service `line-bot`

ตั้งใจ — `botforge-deploy tunnel setup` ตั้ง ingress ตายตัวไปที่
`http://{name}-line-bot:3000` และ `status` / `rebuild` map ชื่อนี้
ตั้ง `container_name: {{CONTAINER_PREFIX}}-line-bot` + `LINE_PORT=3000`
แล้ว **tunnel setup ใช้ได้ทันทีโดยไม่ต้องแก้อะไร**

ส่วน route ที่สอง (`{name}-server`) ใช้ **network alias `<prefix>-server`** แทน
เพราะ hermes ไม่มี container ของ engine แยก

## จุดที่แตะ tooling — ~35 บรรทัด

| ไฟล์ | แก้ |
|---|---|
| `botforge` | เมนูข้อ 10 · `engine_to_template()` · ข้อความสรุปไม่โชว์ `-server` ที่ไม่มีจริง |
| `botforge-deploy` | `detect_engine` (ดู `config/config.yaml.tmpl`) · `get_server_port` → 9119 · `engine_has_ui` → false เว้นแต่ `BOTFORGE_EXPOSE_HERMES_UI=1` |
| `lib/secret.sh` | `hermes` → `DASHBOARD_PASS` |

## ทดสอบแล้ว

ตาม CONTRIBUTING ข้อ 4 — และไปไกลกว่านั้นคือ **รันจริงให้ทีมใช้ แล้วย้าย OA อีกรอบ**

- `./botforge new` เลือก engine 10 → placeholder แทนครบ · `docker compose config` ผ่าน
- `detect_engine` → `hermes` · ingress → `{name}-line-bot:3000`
- **คุยผ่าน LINE จริงทั้งแชทส่วนตัวและในกลุ่ม** ตอบ 1.5–8.7s ส่งกลับสำเร็จทุกข้อความ
  (ใช้ reply token ได้ตลอด ไม่ต้องตกไป Push)
- ลายเซ็นผิด → 401 · คนนอก → ถูกตีตก · เพื่อนร่วมทีมในกลุ่มที่อนุญาต → ผ่าน
- **`botforge-deploy tunnel setup` ใช้ได้จริงกับ engine นี้** — สร้าง tunnel + DNS 2 record
  + เขียน token ลง `.env` ครบในคำสั่งเดียว แล้ว endpoint ตอบ 405 (POST-only) และ
  dashboard ขึ้นหน้า `Sign in — Hermes Agent`
- `/turbo` `/big` สลับโมเดลในแชทได้จริง
- `.env` ถูก gitignore ครอบ · `DASHBOARD_PASS` สุ่ม 32 ตัวให้

## เจ็ดอย่างที่เจอตอนทดสอบ (แก้ไว้ในเทมเพลตแล้ว)

**1. Hermes มีด่านตรวจสิทธิ์ 2 ชั้น** ← อันตรายที่สุด

```
ด่าน 1  adapter (_allowed_for_source)   เช็ค groupId อย่างเดียว → ผ่าน
ด่าน 2  gateway (_is_user_authorized)   เช็ค "รายคน" จาก LINE_ALLOWED_USERS → ตก
```

เพื่อนร่วมทีมที่ไม่อยู่ใน `LINE_ALLOWED_USERS` โดนตีตกที่ด่าน 2 **เงียบสนิท**
ทั้งที่ webhook ตอบ 200 (`WARNING Unauthorized user: U… on line`)
แก้ด้วย `platforms.line.extra.group_allowed_chats` ซึ่ง `authz_mixin.py:478`
เช็คก่อนถึง user allowlist และเป็นทางที่ platform-agnostic

**2. `group_allowed_chats: *` ทำ config parse ไม่ได้** — `*` ล้วน ๆ YAML อ่านเป็น
alias reference  🔴 **และ `hermes config check` รายงาน `Config version: 33 ✓ ไม่มีคำเตือน`
ทั้งที่ไฟล์ parse ไม่ได้** — ต้อง `yaml.safe_load` เองถึงจะเห็น
ค่า default คือ `*` จึงจะเจอทุก project ที่ไม่ตั้ง `LINE_ALLOWED_GROUPS`

**3. quick command ชนกับ built-in แล้วเงียบ** — ตั้ง `fast` ไว้ แต่ `/fast` เป็นคำสั่ง
ของ Hermes อยู่แล้ว (`slash_commands.py:3532`) `gateway/run.py:14855` เช็ค
`_cmd_def is None` ก่อน เจอ built-in แล้วจบ — ไม่มี error ไม่มีคำเตือน
เปลี่ยนเป็น `turbo`/`minimax` + ใส่วิธีเช็คชื่อไว้ในคอมเมนต์

**4. ต้องใช้ `custom_providers:` (list) ไม่ใช่ `providers:` (dict)**
ถ้าใช้ dict Hermes นับ provider ตัวเดียวเป็นสองตัว แล้ว `/model <ชื่อ>` พังทุกครั้ง
ด้วย `is declared by multiple configured providers`

**5. `webhook_path` หลุดคนละค่ากับ `.env` ได้** — เดิม hardcode ใน config ขณะที่
`smoke-webhook.sh` อ่าน `LINE_WEBHOOK_PATH` จาก `.env` (เจอจริงตอนย้าย OA: Console
ตั้ง `/line/webhook` แต่ config ยังเป็น `/webhook`) เปลี่ยนให้อ่านจาก `.env` ที่เดียว

**6. botforge ไม่ publish port ออก host** — `smoke-webhook.sh` จึงยิงผ่าน container
ชั่วคราวบนเน็ตเวิร์กเดียวกันแทน (`SMOKE_VIA_HOST=1` ถ้าอยากยิงจาก host)

**7. dashboard ต้องมี alias `-server`** — route ที่สองชี้ `{name}-server` ตายตัว
บวก `HERMES_DASHBOARD_PORT` ให้ตั้งตรงกับ port ที่ ingress ชี้ จะได้ไม่ต้องแก้ Cloudflare

## ที่ควรรู้ก่อน merge

- ⚠️ **ไม่มีเงื่อนไข @mention** — ในกลุ่มที่ผ่าน allowlist บอทตอบทุกข้อความ
  (adapter ไม่มี logic mention เลย) กลุ่มที่คุยกันเยอะจะเผาโควตาโมเดล
- ⚠️ **Hermes รันคำสั่ง shell ใน container ได้จริง** — allowlist คือด่านจริง
- ⚠️ **dashboard ปิดไว้โดย default และควรเปิดเมื่อจงใจ** — 19 หน้าของมันรวม
  `EnvPage` ที่เห็น/แก้ env ได้ (LINE token, LiteLLM key, tunnel token) และ
  `ChatPage` ที่คุยกับ agent ซึ่งรันคำสั่งได้
- ⚠️ **`hermes config check` เชื่อไม่ได้** — ผ่านทั้งที่ YAML พัง (ดูข้อ 2)
- เทมเพลตต้องมี LiteLLM gateway บน network `llm-clients` และ **virtual key แยกใบ**
  (ไม่ใช่ master key) `.env.example` เขียนเตือนไว้แล้ว
- `scripts/` ไม่ใช้ `{{PLACEHOLDER}}` เลย เพราะ `botforge new` sed เฉพาะ
  `*.yml *.yaml *.json *.md *.ts *.js *.example *.toml` — `.sh` ไม่โดน

## ยังไม่ได้ทำ

- ยังไม่ได้ทดสอบส่ง/รับ รูป เสียง ไฟล์ ผ่าน LINE
- ยังไม่ได้ทดสอบปุ่ม postback ตอนตอบช้าเกิน 45s (ยังไม่มี turn ไหนเกิน)
- ยังไม่ได้ทดสอบ fallback ตอนโควตาโมเดลหลักหมด
- ยังไม่มีทางให้ทีมดู dashboard แบบอ่านอย่างเดียว (Hermes ไม่มี role แยก)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8LCZCwMhJfJJUvK7PP3Ag
